### PR TITLE
Add all stickers from tlgrm.eu/stickers

### DIFF
--- a/stickers.json
+++ b/stickers.json
@@ -784,30 +784,6 @@
     "tags": "",
     "nsfw": false
 },
-"57ea8ca7ad3986d7e95a3398a6b776c8": {
-    "key": "30b9a93c81dbdbff51fcbfefdc17dea4f3d84e96535e54f78d7b038017394d62",
-    "source": "https://signal-stickers.github.io/",
-    "tags": "adventure time",
-    "nsfw": false
-},
-"d8af9737c1c71f32a87281e1bdb281e8": {
-    "key": "db1e657ae019f0e487b60916353f26ad48d95a7af4d75b93d678b78eae7ef051",
-    "source": "https://signal-stickers.github.io/",
-    "tags": "panda",
-    "nsfw": false
-},
-"4710692d80eef97f9883cd9dc7d22aab": {
-    "key": "4f4670296156311d38cd92ce67909e39205ca20534be2d3175660892adeb72ef",
-    "source": "https://signal-stickers.github.io/",
-    "tags": "panda",
-    "nsfw": false
-},
-"b1fb19f90fc509bdb4d8d82e5dbb8375": {
-    "key": "f57e6d57ced01ec176f8e5ce244c67cf6baf0f32a648788da8b470d286da370a",
-    "source": "https://signal-stickers.github.io/",
-    "tags": "panda",
-    "nsfw": false
-},
 "8969c957cbd6ae9d033a4f8d3935a16e": {
     "key": "9c3d2ca44339bca302cdf929e9741b2f7b12556a4dcc8ffabea215d732bbd0c1",
     "source": "https://github.com/romainricard/signalstickers/pull/21",
@@ -854,6 +830,6630 @@
     "key": "5db678fd5bad89552f412b82d623ed034cdd25c85358f12e1872c00bf0c8a479",
     "source": "",
     "tags": "",
+    "nsfw": false
+},
+"f36f5fb3d8dde697e1527650ea1c12a6": {
+    "key": "eb6be23a93685d18568292818f6a4ebd85161b8ae1edca86a06698c1472200f0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Anex.agency, Aaaaaaeeeerrr, девушка, girl, travel, путешествия, Anex.agency, telegram",
+    "nsfw": false
+},
+"67b0a1306e6ca8820a6dc935a4446c0c": {
+    "key": "d049d0187b2dccc447dd75230b124b5ebd50f20645078e9d51935d7298458fba",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Алексей Фадеев, Absdls2, абсурд, рисунки, дудлы, doodles, imagines, картинки, каламбур, Absurdoodles 2, telegram",
+    "nsfw": false
+},
+"fa3e5cc818d6f42ef5ddd6939bd299bb": {
+    "key": "8564c49aaee278882bcdb630ebe9ed292651d5170d026fc87b61059ff58bbcb7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "AccessoriesMasks, маски, животные, глаза, череп, лиса, собака, клоун, робот, парик, пират, египет, викинг, шляпа, шапка, бант, корона, каска, рога, нимб, уши, наушники, твиттер, masks, animals, eyes, skull, Fox, dog, clown, robot, wig, pirate, Egypt, viking, hat, cap, bow, crown, helmet, horns, nimbus, ears, headphones, twitter, Accessories (@tmasks), telegram",
+    "nsfw": false
+},
+"bc5a36e054912cbb3df586975a8f7c3d": {
+    "key": "b2694ff04804747298eed642cc34ac9f7bc18d72e66043b4bb9c13cd9087abcb",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "EeZee Stickers, Actresses_4eeZee, people, women, actresses, movies, Actresses @eeZee_4stickers, telegram",
+    "nsfw": false
+},
+"387b6f73cc00b1646f2e828f6e3df3dd": {
+    "key": "0403e5fc6216247f4bdffefdd7d3a79e18348a88595b8f9ab4c9199a52412436",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Vika Geraskina, Adelemojis, адель, певица, музыка, music, adel, singer, Adelemojis (by @xzawes), telegram",
+    "nsfw": false
+},
+"6826e2daa5f047d3117207fc8e2be5a0": {
+    "key": "7724c0dbab716da27f3a285aafba5ace3faac7db6d2ef575871e7d12840712ff",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mari Inari, AdrianoChelentano, люди, италия, музыка, песни, people, italia, music, song, singer, telegram team, Adriano Celentano, telegram",
+    "nsfw": false
+},
+"57ea8ca7ad3986d7e95a3398a6b776c8": {
+    "key": "30b9a93c81dbdbff51fcbfefdc17dea4f3d84e96535e54f78d7b038017394d62",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "AdventureStickers, время приключений, персонажи, adventure time, series, Adventure Time, telegram",
+    "nsfw": false
+},
+"96a50d2ff5fa0240b23615b3de762039": {
+    "key": "97f01b6ac538ea31c1bce3b205c668a93f8ed3010359af5c9ab22feb3fbf656e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Sergey, AerobicBob, спорт, тренировки, аэробика, упражнения, sports, training, aerobics, exercises, telegram team, Aerobic Bob, telegram",
+    "nsfw": false
+},
+"9364ae881b84736c5b1f346e3adfb969": {
+    "key": "f6eec97f2b0ed1ac088c655a986048efeef31f82ae8814c967129a8167621d82",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Миккель Лис, AgrhViking, викинги, средневековье, мужики, Middle Ages, men, Викинги, telegram",
+    "nsfw": false
+},
+"d8ecb913b2e73a66d66c4056be0b519d": {
+    "key": "0c56323407a489280b7ffeb92effb61b45d9ea3845740a83d92533ef114ebb27",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "AkitaYoshy, акита-ину, Akita, собака, животные, dog, animals, новый год, Akita, telegram",
+    "nsfw": false
+},
+"1b9fd9dd18e98e0d525362193e5b4fab": {
+    "key": "8dea5ff9b27f1df95a7525526bfd62c0e4e651bf10e7f4acb5a90f09ef07b8d9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Софья Шептухина, Alex_the_Raccoon, raccoon, енот, животные, animals, Alex_the_Raccoon, telegram",
+    "nsfw": false
+},
+"130f0c86c1a768e78b392f65dbc00831": {
+    "key": "bab98859574fd4ab9644eb11d536775401870475d3c8ca9412c85de007fdb37a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, AliceFox, девочка, люди, аниме, лиса, животные, animals, people, girls, anime, Alice Fox, telegram",
+    "nsfw": false
+},
+"265436049f9c06a6e0d180724718cfd9": {
+    "key": "0a837b020d204cf3e1a94f1a62cbe7336d412eec3023f5bf86345461be6c40fe",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, AlienGuy, фильм, монстр, чужой, робот, Movie, monster, alien, robot, Al the Alien, telegram",
+    "nsfw": false
+},
+"e1ebbeb223685c27b7217287c5d336dd": {
+    "key": "c9fb4a1f660f0ea45797737e6482c74ecc749ea242ba9280134a935b0f5e896f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Филинков, Alien_AFilinkov, космос, инопланетянин, Ufo_AFilinkov, telegram",
+    "nsfw": false
+},
+"5712d901abf0f1802b838ec371725317": {
+    "key": "ea1ee30ae847f657e33e3ff03e5ff134f667e34da4ee22eda6da0fce182aa0e7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "AliveMonkey, животные, animals, обезьяны, monkey, Mona Monkey, telegram",
+    "nsfw": false
+},
+"3ae3df67af0a1de21a20332076520220": {
+    "key": "da59b5f54c1a6ca2048c496883a23a99f902721df45182b5ca0a3c3f1d4453d1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Allisold, алиса, мультик, сказка, cartoon, Алиса, telegram",
+    "nsfw": false
+},
+"4012da5c6d9b2e0bd08ba4499870fc36": {
+    "key": "4d6fb08e5a813d68bb707d32b951bd0605b0b9b41312d167789c1bb2961e6a8b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Amanita, грибы, mushrooms, Amanita, telegram",
+    "nsfw": false
+},
+"10ba959be2a9605bbabd648f317657ea": {
+    "key": "3db92dabcf8a1059921e007e4b22e0fc9ebaba3d4f1f9133c7a1ce211e4b2b86",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Nataliya SILICH, AmurTiger, telegram, cute, animals, tiger, cat, кот, тигр, животные, милота, Amur Tiger, telegram",
+    "nsfw": false
+},
+"72dddd95bb9be3c3736009aacaf2dd65": {
+    "key": "68b3297b78e8440bc9d98b77a867a3512d071fb3b07b68909dd38fe58c8a38c6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Animalnyan, животные, милота, animals, cute, Зверюшки, telegram",
+    "nsfw": false
+},
+"22545faf0fd7c142e79142ce28e7559c": {
+    "key": "dff45eea77792bc5157a4ea5eb6fd9e6a20e00321c2f07101bc1279230797301",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram, Animals, животные, doge, мемы, панда, кот, собака, педрила, енот, медведь, animals, cat, dog, raccoon, Just zoo it!, telegram",
+    "nsfw": false
+},
+"d60e35e80ace1bcb060439d7691b71ed": {
+    "key": "fb76842dad09fdcb89c2366ca833fdd53757517fc9b5c8a03d8f1b594c941f54",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Корнев Иван, AnimalsKids, животные, милота, малыши, дети, animals, cute, baby, Kids Animals @StikeryTG, telegram",
+    "nsfw": false
+},
+"54e3e3053ba774762bdc1401a812c3b4": {
+    "key": "fe9613eee7a176ed1a232b54b02597079b2b3bf3de0d7dd0cd743df4b98eebf1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Стася Лёва, Animalsloya, животные, animals, Animals, telegram",
+    "nsfw": false
+},
+"19c5fa5abee773c097707b75b49220e9": {
+    "key": "b0dfade0bdcac3cb98b382078ca8af7df342a4ec01269f0b1617371a1a0a8ff8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "КиноСтикеры, Anime_mem, аниме, мемы, anime, Аниме мемы :: @animesticks, telegram",
+    "nsfw": false
+},
+"f273f09cd9802c611e46a8a826967342": {
+    "key": "1c0b89ec925e573ff811cb8dd7da72e507b7e838b1bbf85c615da4963505c458",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ankou, анку, смерть, death, muerte, Ankou, telegram",
+    "nsfw": false
+},
+"8fc9ce41b1434d57ec39d9ffbe4cf242": {
+    "key": "2d95f25dc4667469b276e8aedbc8dfb269aeace37b239626e881d768b2edb749",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Demari Ri, Anksi, животные, лиса, fox, animals, Tommy, telegram",
+    "nsfw": false
+},
+"eb9534c3b5af5804db1d9b38b8d113bc": {
+    "key": "7779428d3c21848cc5e622d065a3af8c909d48cffd20bbff9aebbbffefc76540",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Serbun, AntonioMontana, лицо со шрамом, scarface, фильм, telegram, деньги, Tony Montana, telegram",
+    "nsfw": false
+},
+"406e3a39f2762dbe221d60c3c6b1b325": {
+    "key": "7f6f6be27b56ffa50c3c75aa80b328baedacd74870ef94137d0f884284de2334",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Anurognathus, ammy, anurognathus, pterosaur, dinosaur, extinct, pug, cute, weird, динозавры, армия, Ammy the Anurognathus, telegram",
+    "nsfw": false
+},
+"250328dfba8602e5246af991b5698391": {
+    "key": "bfeee068ce11aaa19d16724bb0474183d784e1b9e73e89a9badfd9837d4f95a8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Aphrodite, божество, deity, myth, mythology, goddess, greece, миф, мифология, богиня, греция, 14 февраля, день святого валентина, любовь, отношения, сердце, Valentine's Day, love, relationship, heart, Aphrodite, telegram",
+    "nsfw": false
+},
+"5729bec50948d2a146002a9d36286fd0": {
+    "key": "c67fc478e867c17534bcc17c484dc87bd4d125acee5786b73302abf5fa738356",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Apollo, аполлон, боги, греция, мужчина, красавец, apollo, gods, greece, man, handsome man, Apollo, telegram",
+    "nsfw": false
+},
+"78f468eeaafcbaa9b4c39c9e01c994d8": {
+    "key": "ee76a1e54fb4d4da5371d79e70bf92ccf7e7259c224826aaea735775362c1b0f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Krasivon Art, AppleSteveJobs, apple, люди, бизнес, people, business, telegram team, Steve Jobs, telegram",
+    "nsfw": false
+},
+"02dc9e035e8c3715df5378ab8182ed74": {
+    "key": "46601c827d958f1a93223789d2e8ae29a60a9dad10e0c8307c5eaf6b7c5bacf6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Enigma Eklz, Archie_stories, fox, animals, животные, лиса, Fox Archie #archie_stories_ee, telegram",
+    "nsfw": false
+},
+"67be64de508ce17a830d61b84cbb1c90": {
+    "key": "03de39dcf7033f93de35eea0cbc575d05554ecbfb1182d29fb874522c3eb8616",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Boggart Owl, ArmBirds, птицы, животные, руки, юмор, telegram, berds, arms, Birds With Arms, telegram",
+    "nsfw": false
+},
+"3c83423ada05e6915618efb82dc46404": {
+    "key": "7d57ff9ff6e0c4b3d0dbf30db421b3922cfe3008ec652b17f676fd7f3380d73d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Arthive.com, Arthive, художники, картины, искусство, арт, культура, Artists, paintings, art, culture, Artists by Arthive.com, telegram",
+    "nsfw": false
+},
+"6074c7e997a54d34dc36e625b3495db0": {
+    "key": "0f4e925bdbd8f2e4be74f13b1886450da1bf69d5544f0414fafab944c56efc1d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ulyana Tkachenko, AryaStarkGoT, игра перстолов, сериал, герои, game of thrones, series, character, telegram, Arya Stark, telegram",
+    "nsfw": false
+},
+"ad10af4ffc64e29f7aa9de29111cc986": {
+    "key": "34ade1a25b3f1dc2997946f45c12d0a9bd76a58fe2db0e97cc13ca6458da2b6d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Arzamas, ArzamasDarwin, арзамас, дарвин, эмоции, люди, emotions, people, .\\-Darwin, telegram",
+    "nsfw": false
+},
+"fdf2dbaece4544b76b36772bb01a68ec": {
+    "key": "080fb86fa17c6af7aa378476f2ae3fb9f8343f5f06380c585f06425bec587718",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Astartata, art, girls, рисунок, арт, девушка, Astarta, telegram",
+    "nsfw": false
+},
+"eb119ee551d35c5bbfa3601e41933099": {
+    "key": "99e178ca39102483f1cd2bf5a8db54c9a9778ecd7efa8f5e26312bb89aea2a07",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Наталья Ошестюк, AstroKitty, кошка, конкурс2016, cat, animals, животные, Astro Kitty, telegram",
+    "nsfw": false
+},
+"ea34dc161f75c8a7a9588da2fd7e8186": {
+    "key": "a3bfb0e7bfda6ea9f8d976fbd65a11170f146c6490c4abaf776683341ef4be19",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Алиса Регель, Astrolamb, lamb, animals, овечка, животные, AstroLamb, telegram",
+    "nsfw": false
+},
+"4b3ed0ba41530cc5c17faef6d94bd793": {
+    "key": "0995c632250a59ada3aaf04e890e738d92f3ed2aebdc97305e5d1730798a5450",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "AtsuFawx, animals, животные, Atsu Fawx, telegram",
+    "nsfw": false
+},
+"42c4bff6929bf632572b01d2ee9d7f02": {
+    "key": "97780d77996ba501ee9967949e253e974dd502b4475a6267b0633e84548e3f20",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Илья Шаповало, AudreyGlamour, одри хепберн, тиффани, завтрак у тиффани, мультик, cartoon, Audrey Hepburn, актриса, tiffany, конкурс2016, Audrey Glamour, telegram",
+    "nsfw": false
+},
+"d44ce6386a5493f259d9439a96ac41c0": {
+    "key": "127f4bf2c3f03e19d8b66ceacb4e7a63235b12a1e46c4228c6a0d06e13d358dc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Autistic_love, кот, жиовотные, любовь, отношения, секс, пошлые, эротика, sex, cat, animals, love, Autistic love, telegram",
+    "nsfw": false
+},
+"238f8708e68cba25f421db292cdcbad1": {
+    "key": "4050eee7ecf533dba372919b103ef89ac3e2b96a4add5b9266a634cd0c064300",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, AvengersHeroes, фильм, супергерои, movie, superheroes, Avengers, telegram",
+    "nsfw": false
+},
+"2d9a5f328d6f555285344b45f098c4b4": {
+    "key": "e5ef761339215e225604f7e6702796929ad75a7babf45afa8d7e2a6a7ef166e2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "AyiTheDeer, олень, животные, animals, AyiTheDeer, telegram",
+    "nsfw": false
+},
+"41da06f34a13024f1f8832b1d1ce5d9e": {
+    "key": "3b473d87b78d1f5c271f1f14137f371a8a6e44aa5b2672d95200915624170eb6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "AZAL, AzerbaijanAirlinesPlane, самолетик, plain, азербайджан, туризм, путешествия, транспорт, turism, AZALplane, telegram",
+    "nsfw": false
+},
+"75459804bdfc3fe2dcf3f0a6c1626df6": {
+    "key": "e4e813e30d7842d438eb054ee6d8fcf89b5a6dd84c75884f5f4e486b087021e3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "BF_Sheen, пес, собака, животные, animals, dog, Sheen, telegram",
+    "nsfw": false
+},
+"327324fcebee242f3bd61f1aba44c12f": {
+    "key": "f2efed60642e0d75b77bb6f5daf30629b0133f2a4419d5e3d91ac448dd261d0b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Facebook, Baach, facebook, фейсбук, животные, овца, баран, sheep, animals, Baach, telegram",
+    "nsfw": false
+},
+"6068b7030aa8fd458682730147e7e32b": {
+    "key": "508ed3e22b655125870957bbdf8e50a362868765f1cda0934572455f8f7e864a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Макс Гусев, Babycado, babycado, малышавокадо, авокадо, еда, овощи, food, avocado, Babycado, telegram",
+    "nsfw": false
+},
+"1d64a016f34912780de6966d74b69e4e": {
+    "key": "f7baa9b404b8ba4d1965b3d3d968b3d78af58496cd276eec7dc7f8e133030978",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "BackToThe80sMasks, магнитофон, галстук, плеер, кассета, парик, телефон, record player, tie, player, cassette, wig, phone, Back To The 80s (@tmasks), telegram",
+    "nsfw": false
+},
+"0f088a75b61cc09fd04c2523a529ad5b": {
+    "key": "b528eb2d9c03cbec6f7a618b18b979947083673a20dad12f1a972127a7acbeb0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Олег Никишин, BadBoyKorgi, собака, животные, корги, dog, animals, corgi, Bad Boy, telegram",
+    "nsfw": false
+},
+"33c12f18606bd677a11a7738a3468e54": {
+    "key": "20daff125222dad90a559f9336a0e33faf5d070dd7de6538e84c92e864d6f6df",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, BadassDisney, мультик, принцессы, дисней, для детей, cartoon, princess, disney, for children, BadassDisney, telegram",
+    "nsfw": false
+},
+"9b51aaedfc23aa08cb4223dee15bdd58": {
+    "key": "f1b1f8f1f5e4cb4db66367fc7e1cba5db614c2c0877dd00443dc3815f5e6940e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "BananaDude, fruit, banana, банан, фрукты, Banana, telegram",
+    "nsfw": false
+},
+"a32a109f61fab9d0b942b5ea4f57de1f": {
+    "key": "6031bb347e5c6475d453dd3f90fe408d4a58522d04d669aa1e4974621172617d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Revenge Meow, BanditRaccoon, енот, животные, animals, raccoon, Bandit Raccoon, telegram",
+    "nsfw": false
+},
+"7382c370dfb56dead4689b44556a78a2": {
+    "key": "1c8bef3edfec963ecb373609871b74f657c2b3f11f3c81557e8c6be26b25b5e0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Рута Михеева, BankerFrog, лягушка, животные, деньги, успех, бизнес, frog, animals, money, success, business, Banker Frog, telegram",
+    "nsfw": false
+},
+"87cc09a68036a33d5d9c3cecebecf60f": {
+    "key": "e39818ae4019230d5b2ec8b4277fd95dde6ffa9a29c33677e8a2ad636351a380",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valery Matyukhin, Banny_By_Osmer, вконтакте, животные, animals, Banny, telegram",
+    "nsfw": false
+},
+"8045f27a529168e363b22b637c9d0071": {
+    "key": "f16b09ab9992b10a67de2e510ee69f22991a1dc693a743a9f97267a4ed92ac3e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "BarneyStinson, как я встретил вашу маму, how i met your mother, movie, фильм, telegram, Barney Stinson, telegram",
+    "nsfw": false
+},
+"ea401d065b3773d67340600093838af7": {
+    "key": "c5654e85832689611da2761fb5cbf2e594eb6d271f51874173c78ffe3134813e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Андрей Козлов, BatmanComics, супергерой, комикс, фильм, superhero, comic, movie, Silver Age Batman, telegram",
+    "nsfw": false
+},
+"6ca7b5f893f160ed9a1a836634aa85e8": {
+    "key": "00b11d96eee3347ecba7debdfcb1a4fd96e0484cdee92ec96f8d7d1cf352256b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Batman_By_OsmerOmar, tv, film, фильм, люди, герои, Batman / By OsmerOmar, telegram",
+    "nsfw": false
+},
+"c52329e17e56cf06c3bf969f02a90cd3": {
+    "key": "78e1bdc45720cbd7cd5f01697eb2f8da1a2510e398141117eb14a8a4246e7a57",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Viktoria Moloko, BattyBat, flying mouse, летучая мышь, животные, animals, Batty Battons, telegram",
+    "nsfw": false
+},
+"e11c7c2b4409311bf3b5841ed74b45ce": {
+    "key": "a1846c99cf736c26bc88fd86e14ce8361906541e4f1b9eba2edf169a0ff2aaef",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "BbyNeverTellSG, comics, BbyNeverTell-ENG, telegram",
+    "nsfw": false
+},
+"95bfb4c8294582e8988f3362ca055a3d": {
+    "key": "28b7ff83cfa4b167064359566f1bcb15196b8f7ba2a24eb4c1cca0ecf3a46748",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Cake One Love, Beaver_by_C1L, бобёр, животные, animals, beaver, Beaver, telegram",
+    "nsfw": false
+},
+"9433d05230e399617277b73a4b23191e": {
+    "key": "42716824a8974feb716e431de7bbf640fa41462f2f6140e9daa971ffdc528dc0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Beeline, BeelineRacoon, facebook, енот, животные, фэйсбук, animals, Raccoon, Beeline Racoon, telegram",
+    "nsfw": false
+},
+"4e61ccea5eb9541a2f300293761fdad3": {
+    "key": "9d99b61a1ee94edce22ecec4c47d7bae977ee0a6fad112c23b50df2b69cf898c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, BeetlejuiceWorld, хеллоуин, ужас, страх мультик, человек, пижама, halloween, horror, fear cartoon, man, pajamas, Beetlejuice, telegram",
+    "nsfw": false
+},
+"34e026d84a264e7e46e2ce19172d75d4": {
+    "key": "ef323a005fd479a474107648dd097b14d7ba0301d070dbb8580b0debbe1299b2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Belfort, деньги, богатство, брокер, мошенник, money, wealth, broker, swindler, джордан белфорт, Belfort, telegram",
+    "nsfw": false
+},
+"60fbc28a1e9bff1fcb9e43116342179f": {
+    "key": "5494eda40a8d38dfab3849a7cc7413c11297d9411a2d597363b62184e0672776",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "BellaTheSquirrel, животные, белка, squirrel, animated, Bella, the squirrel, telegram",
+    "nsfw": false
+},
+"74a1aa1811f52761fafb827d8064551f": {
+    "key": "6e08a3536debcdce9110029decccef51f0afdefe8899199c4253209d4b49feb2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "El'ton Digital, Belyash_korgi_illistrator, иллюстратор, корги, собака, жизайн, животные, Беляш корги - иллюстратор, telegram",
+    "nsfw": false
+},
+"3fe01fc48efa1b95dbef5e31cbbef91d": {
+    "key": "f9a276451fe1351ee116b4cd584e93ee75c7399ff0dcfb45c9f8ad01bfb8695a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Revenge Meow, Bender, футурама, robot, cartoon, futurama, робот, мультик, telegram, Bender, telegram",
+    "nsfw": false
+},
+"f9048b12884a86d141b7bc3aa338679b": {
+    "key": "009eb2806b71add4856463dd04ac0a7597f5dee8d45827314b598200aba4e6f3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, BetsyAndFriends, женщина, девушка, девочка, люди, girls, peples, woman, Betsy, telegram",
+    "nsfw": false
+},
+"e6aeccb25a0398a0d2b9b4cc0bbfde70": {
+    "key": "f669a27a73e4a7c2db94e34a8784d306734d0336dccf2b929dd524608cdb01f2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valerii Matiukhin, BigBodybuilder, качок, спорт, тренировки, спортсмен, мускулы, лысый, мужчина, sport, training, athlete, muscles, bald, male, telegram team, Bodybuilder, telegram",
+    "nsfw": false
+},
+"c63204891bd525ebb87bdeccd2c7d4ce": {
+    "key": "9857216feb2d2ef873a042b1c91137315f269fb3c10fff97ba3ca06dcfd8623e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Настя Тёплая, BigBossCat, telegram team, босс, начальник, директор, кот, животные, работа, boss, director, cat, animals, work, Big Boss Cat, telegram",
+    "nsfw": false
+},
+"3a2e55a535c23ee1a80471f0d2393b4e": {
+    "key": "01b6c1f71099ee575334859b550b69d340fa1148ba17600c219bd36112626867",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Sergey, BigfootEddie, telegram, snow, новый год, рождество, зима, new year, christmas, winter, Bigfoot Eddie, telegram",
+    "nsfw": false
+},
+"c5a754d89fcb3a0781e8ae3892f45aad": {
+    "key": "add737ffd8630e39ec17f8d3cfc971af3ad1780f62c9850cea9a89f94818789e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeriya Sikorskaya, BillieEilishFan, telegram, люди, музыка, певица, people, music, singer, Billie Eilish, telegram",
+    "nsfw": false
+},
+"28923b164fb559b665b80645d234b800": {
+    "key": "4f0438ae2b2917311959654f8b8c631951728542735af6363a2814fe1256d1bb",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Kiselmix, BitTube, bittube, криптовалюта, криптовалюты, биткоин, деньги, бизнес, BitTube, telegram",
+    "nsfw": false
+},
+"b63fcdbe50049f7d340d424954c05f11": {
+    "key": "7e6def7cbe0e6dd692180442dadfa39286a302d69ecaf33b56e53b920723d1d2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Kristina Kaspi, BizarreShinigami, sceleton, скелет, шинигами, Shinigami, Shinigami, telegram",
+    "nsfw": false
+},
+"03b4b2c8ee92dd89dad995d5c38611ad": {
+    "key": "a0caf04039f2c209412058177e7d44a08e5894644cdd1915b0c7c7c89d3284db",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Boggart Owl, Blahaj, икея, ikea, sharp, акула, животные, animals, telegram team, Blahaj, telegram",
+    "nsfw": false
+},
+"37d2ae1651f5f044bac6fefa92ec231c": {
+    "key": "dcf22e8aa7b3839d838e045fb9884e949d58fff8c790e1bd8f864b0751b2a6ea",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "BlindGang, монстрики, милота, cute, mondtres, Слiпарики, telegram",
+    "nsfw": false
+},
+"70bd9f394651949f5c24e3a412628f2e": {
+    "key": "71b4481b6db8a24348dbd773850e642b7b3190a2705e369b5442ebea6da0869f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valya, BlondieVacation, telegram, девушка, отпуск, отдых, лето, пляж, блондинка, море, загар, girl, vacation, summer, beach, blonde, sea, tan, Blondie Vacation, telegram",
+    "nsfw": false
+},
+"f8a37752856b76e132f8b44e66f0b2b0": {
+    "key": "f8f883616a3266d326e2652a0a2cda33f58f6910055c6a953931c9350fd0c2c3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, BlueGhost_byAlexzhdanov, ghost, привидение, монстр, монстер, арт, Синий ПРИЗРАК @TuristasTV, telegram",
+    "nsfw": false
+},
+"9ad441592c99909cb8a999373eed085d": {
+    "key": "caf7491733d5f6b7c996a0ad1b13702c94eed00d4806e7cac3d384976333bb6d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Daria Kurkina, Bonifazi, кот, животные, animals, cat, Бонифаций, telegram",
+    "nsfw": false
+},
+"ff5cd80f4a389ff64985574099aed4fe": {
+    "key": "4804a35d703d2316e0ae389ab2fe6736fd2f0cd08e3d502744d1443024f41f6a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "NTLENT, Bonnie_and_Clyde, любовь, отношения, романтика, 14 февраля, день святого валентина, фильм, любовники, грабители, преступление, love, relationship, romance, february 14, valentine's day, movie, lovers, robbers, crime, telegram, Bonnie and Clyde, telegram",
+    "nsfw": false
+},
+"5eb07e7815a9a8c8450b88a12791805f": {
+    "key": "6000a7e64999db2d25def38d8c59d6e50d636591ec4b0b51b86a569804c6ee69",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Bonycat, скелет, животные, кошка, cat, animals, skeleton, Bonycat, telegram",
+    "nsfw": false
+},
+"0ce8fd37cc79e8a9388e10ff87f2a2b5": {
+    "key": "86d25b894a7160255279964d2b20497e4324c609f24d211a73b6ab38b2e7fe21",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Dhruv Saxena, BooHike, монстрик, милота, monstor, cute, Boo, telegram",
+    "nsfw": false
+},
+"0116c62d63c2b94c5e2aad0b95312fe2": {
+    "key": "58631d93de83605833e5e63b17f19a133b26aaf3373c0b57018864d961d7d88d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Daria Tyusenkova, Boone_vk, вконтакте, мопс, pug, animals, dogs, Boone :: @mosticks, telegram",
+    "nsfw": false
+},
+"49d6aed7f66288b059e09a12b2e357f3": {
+    "key": "2b14fcf4314271c5b01df19bf14013b3ffdc1c9c877a962f561ab72b88808e5a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Darya Ogneva, BornToBeAUnicorn, telegram team, единорог, животные, радуга, unicorn, animals, rainbow, Unicorn, telegram",
+    "nsfw": false
+},
+"c7c9c25c658f371acbcad919fcb77f2b": {
+    "key": "d1c6f84b38d27c913f511b1c92a0a04688824bb4300d7fc8f220437ab09d4576",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ilja Shapovalov, Born_To_Die, people, singer, song, music, певец, песни, музыка, люди, telegramteam, Lana Del Rey, telegram",
+    "nsfw": false
+},
+"3d03bf635ed40d78a8c698f430bb7658": {
+    "key": "9048e7574a68f7078364aa55f9b6f5a7f46036bb05280f637384e6e578dda35b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Anton, BottleMessage, звезда, авторские, star, Bottle Message, telegram",
+    "nsfw": false
+},
+"ca3aa6e841558a8b08aff21b95964994": {
+    "key": "c1d6ee299182499ba519548faaaa8241781b430e2bb12e563faf9a0783a62d45",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "BouncingCats, кот, животные, animals, cats, Bouncing Cats, telegram",
+    "nsfw": false
+},
+"0210c780e6852f59e24f537a371efedd": {
+    "key": "47f0bee0d478a49e09e089424ce3d1b1401a34122100e0dc5523714d675487d2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Анна Шумская, BoyWhoLived, фильм, гарри поттер, кино, книги, сказка, для детей, harry potter, movies, books, fairy tale, for children, forkids, telegram team, Harry Potter, telegram",
+    "nsfw": false
+},
+"343237d69380c8b6e208b1af7d4e5c5a": {
+    "key": "1317025e0044131ccd27a3ad032b32e582f5ad2866a5569e1511b4261d6d276c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "BreakingBadStickers, сериал, гейзенберг, герои, TV series, heroes, Breaking Bad, telegram",
+    "nsfw": false
+},
+"bd237b48d187532a24e55c2b355ea3ae": {
+    "key": "08aefc559c5ab900f2738a218565f68834d679b3697a6f8030313bef8f81f18b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mary Virgin, BrianStewie, брайан, стьюи, гриффины, дети, животные, собака, мультик, family guy, cartoon, kids, animals, dogs, telegram team, Brian and Stewie, telegram",
+    "nsfw": false
+},
+"f11f4d2aacb9145c474f8903da598961": {
+    "key": "95f1c22a2f70c01d9675ef904c09578ef5c92f113938f4bb9e8554410334d6d7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Владимир Хаецкий, Brick_Man, игры, лего, человечки, games, toys, kids, дети, telegramteam, Lego Is Awesome!, telegram",
+    "nsfw": false
+},
+"e6b1e567c1060474e77238294f704b51": {
+    "key": "d5b12c1c650dbf18240124c69fcbbedae1895901c2b8e05c67014a211f30b6ce",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mari Inari, BrofistPewDiePie, telegramteam, блог, ютуб, blog, youtube, PewDiePie, telegram",
+    "nsfw": false
+},
+"cf238b5b86d5e2c3e8f0a39b1731e551": {
+    "key": "0f1f37b2da8c083e63c71573273b18525cdf833eea76075a776867c66612669f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "BrokenCats, коты, cats, кот, упоротые, Broken Cats, telegram",
+    "nsfw": false
+},
+"3967d026a117903acbd8526ad6dd97c8": {
+    "key": "73877ed174852c3cf762bd7eaebc9809ed310ac1702a6311ac0d7fb0397343a5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Broken_Animals, животные, animals, юмор, humor, fun, Broken Animals @TgSticker, telegram",
+    "nsfw": false
+},
+"1404a17bcf9a7fcac628d59e5a128f1c": {
+    "key": "ec655c506137f526cf625f287a3c179d547793a9c833378dc84dd98f93e13ddf",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Krasivon Art, BrotherhoodBald, порно, секс, любовь, лысый, мужчина, мачо, бабник, день святого валентина, porn, sex, love, bald, man, macho, womanizer, valentine's day, Go Baldly, telegram",
+    "nsfw": false
+},
+"ed1b74dfb07917fb59005c969fc8e37c": {
+    "key": "06f9ae9020de0ff265739fbae5a8d1a88187887fdeb2a56442b4be75365fd9da",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Олег Ходячев, BsAiRmTpsons, мультик, симпсоны, для детей, simpson, bart, cartoon, tv, Bart, telegram",
+    "nsfw": false
+},
+"ccb45b55daee71795ddbac25d8711c04": {
+    "key": "aa69a0cc135efdccf7ea85c758a5605e01217efaf4c299f870a3e16847897fb3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valerii Matiukhin, BuddyBear, telegram team, bear, cartoon, forkids, мультик, медведь, длядетей, Winnie the Pooh, telegram",
+    "nsfw": false
+},
+"9e34114b4022674607263548fec2d0b8": {
+    "key": "32ee170e505e3427cd6e8ed8055219d3b7b75dc8fe48916c7ef92a7371bd3f68",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, BullAndBear, бык, животные, медведь, криптовалюты, токен, деньги, bull, animals, bear, crypto-currencies, token, money, Bull & Bear, telegram",
+    "nsfw": false
+},
+"f9205202cfcbf99a55a1d82c79e11940": {
+    "key": "032a23b301c29331412ea104b52ffc018e5b223b5793217093124f28f748eaff",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, BunJoe, собаки, животные, animals, dogs, Bun Joe, telegram",
+    "nsfw": false
+},
+"0336d8f0b1d38a25476463896f7143c2": {
+    "key": "0e0840bba4de7ca14fa2e6b902422a2734b4285ca3c87663059c7b2bbb0e79af",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "BunnyBun, заяц, кролик, животные, animals, bunny, Bun, telegram",
+    "nsfw": false
+},
+"e5e6af712476f2255ae2ad8090b3bc0c": {
+    "key": "a0ad0fe3f73c042d52d65fac262c2f4c7ff3b53bc1a369651e77731cb4961d6b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Анжелика Кирюхина, Bunny_Boo, животные, animals, rabbit, кролик, конкурс2016, Boo the Bunny, telegram",
+    "nsfw": false
+},
+"311ced4ae61e84fef1a3029403c47b40": {
+    "key": "5a97af446633859a7cf95ae372543c90ec3dee77416d6e2a6a2ce1e3d65829c7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "CNMHLCS, эмоции, люди, кино, сериалы, people, emoji, tv, movie, Cinemaholics, telegram",
+    "nsfw": false
+},
+"ca342d0fe07ad9a7574adc178c28e058": {
+    "key": "f4acc5c68596a132401c0d944c4d4461d5dd863f7a02f13e58665b65e6f76dd8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Алиса Регель, CakesandFlowers, торт, цветы, праздник, поздравления, 8 марта, день рождения, женщинам, еда, сладости, букеты, на праздник, cake, flowers, celebration, congratulations, March 8, the day of the birth, women, food, sweets, bouquets, on holiday, CakesAndFlowers, telegram",
+    "nsfw": false
+},
+"0317ea19b797a7398a2add28312f8319": {
+    "key": "f4c4388e6d1a3ce62e555b63a38987b4e139d93e65db9cd4894d3625f9fb5256",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Cannamela, единороги, животные, пони, unicorn, pony, Lollipop, telegram",
+    "nsfw": false
+},
+"fc1d1820e6ad5d46e9945d6a4b1d71a4": {
+    "key": "a4b651a09269db920e07c1611790a3d6f9016a9e5ab7faa0fd882f529a4967e2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Andy Aslamov, CarbotRepainted, арт, art, carbotanimation, Carbot Repainted, telegram",
+    "nsfw": false
+},
+"8bdc6aab52c7eacb79b866921127fb7a": {
+    "key": "3f170b261937597be6edccbcd6ec3faf296dc373a9f7c098f9565eeac30da821",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Carmelo_By_Osmer, животные, animals, ящерица, lizard, Carmelo, telegram",
+    "nsfw": false
+},
+"e5ebd35d33a7d51b35dca91ef62188c9": {
+    "key": "b9bec119158f0a1a24873d9785451837bc0499b3b20e9826aec490bb484698e5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Darya Ogneva, CasperGhost, telegram, ghost, helloween, хллоуин, приведение, каспер, мультик, cartoon, Casper, telegram",
+    "nsfw": false
+},
+"795493c00ab7f275010a120cc82a8bf9": {
+    "key": "6baac158835b216367e5c14dfc31af678a8d759dea596f001993a26336dce250",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, CatMeow2_byAlexzhdanov, коты, cats, животные, animals, Котики и Кошечки 2 @TuristasTV, telegram",
+    "nsfw": false
+},
+"d6a9a92b9bef333c28b47ad507cf020b": {
+    "key": "f3531bb417414d5f477a5777f782cc993fa14be2bb93ba75eca9da1a7cdfd92c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "CatPusheen, кот, котик, животные, facebook, animals, cat, пушин, pusheen, Pusheen, telegram",
+    "nsfw": false
+},
+"49075a7b0c8f8d6744c8e25e8c2806a7": {
+    "key": "897905227cc3e4b5a65ea069397c419499d59c1b455c4502d0e537029d7758d5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Bird Born, CatStepanBirdBorn, кот, животные, cat, animals, CatStepan (Bird Born), telegram",
+    "nsfw": false
+},
+"1c20216ddc6a57b1d9eac8a5eeb2c4be": {
+    "key": "d1ed855b865e8f5fff9e07d9f2cdde0967765cb302f1719a604e6359b28f9111",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Дарья Цветкова, Cat_Collection, кошки, животные, animals, cats, Cat it!, telegram",
+    "nsfw": false
+},
+"815fdf4efcf1ff28cddfd0cab5b999ea": {
+    "key": "1f7908a65c97bdb0d4116891ffce9789c43678975472a6d541d60704f29c8962",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Cat_fullmoon, кот, животные, милота, cat, animals, Cat Fullmoon, telegram",
+    "nsfw": false
+},
+"e135cabf13d70cd44543be4bfce80eb4": {
+    "key": "11b7ac1026e5e96f0fbd71e2e0067c57191300ba032292b2ef63472efa871045",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Cat_line, животные, кот, animals, cat, Mahdiye_ss, telegram",
+    "nsfw": false
+},
+"14b408f6c300d014cb65628e13cad8c8": {
+    "key": "7ca0f201206a9c12faffb78556ab5f66ad0472d1abcb10d303c2fa1f4fe66d43",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Cat_msg, коты, животные, забавно, cats, animals, fun cat, telegram",
+    "nsfw": false
+},
+"6bb02b2529972ccfd5bbd9311183113d": {
+    "key": "261082ba5899b0dab8dbf42de271654c47b794c9ddfdb0a5562ba233bfbda35c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, CatrinaCalavera, искусство, obra de arte, скелет, skeleton, art, хэллоуин, Halloween, horror, ужасы, череп, skull, Catrina Calavera, telegram",
+    "nsfw": false
+},
+"73fa06696c45dd02c6d7bd2f1b957f9d": {
+    "key": "193d2f3dcadbb176c1e9c650abfb265da615f9521329e17b48e51e6c83ec659a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "what being sensitive is like, CatsInCircle, кот, животные, арт, cats, animals, Cats in Circle @besensitive, telegram",
+    "nsfw": false
+},
+"eec4f9dd7bd79f49e16e4cc51050fa87": {
+    "key": "2888a33bfa42483d0876f077c734565dd536fb77c8b62da3a78e4ac06202fbde",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Корнев Иван, CatsNice, кошки, животные, милота, animals, cute, cats, Nice Cats @StikeryTG, telegram",
+    "nsfw": false
+},
+"fa13bf6690341a2e38844ddaa6897539": {
+    "key": "893942d42ec6c8803d30c74b94b869141ef25f673309f754ecf991f91c46ddd5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "CheGevara, революция, куба, revolution, Cuba, люди, people, Comrade Che, telegram",
+    "nsfw": false
+},
+"89465bb717ed6cd261884a155bc7466d": {
+    "key": "39482e546ede8ee0a841c8a1eb3fd3e289b77f38a4d8390fe84ab5210b194773",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, CheerleaderGirl, люди, people, спорт, группа поддержки, sports, Support Group, Cheerleader Girl, telegram",
+    "nsfw": false
+},
+"3b2a79ca0f17c829cbbd3e5cd7d82104": {
+    "key": "50c4ee9142b7fb9b3f3f9634f5700590b3630f7f00de75e9880d664d57a32f50",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Cheshire_Smile, льюис кэрролл, алиса в стране чудес, кот, улыбка, Alice’s Adventures in Wonderland, сказка, cat, fairy tale, Cheshire Cat, telegram",
+    "nsfw": false
+},
+"8255383770bb33aeef3f02a480e89a25": {
+    "key": "26ad18176f39cf5626727d6046659cc5cc7583e2dd459bbcb44c4e32cdd0a52d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Anna Kostiv, ChewbaccaWookiee, звёздные войны, фильм, movie, star wars, telegram, Chewbacca, telegram",
+    "nsfw": false
+},
+"51b0fdeec9f25be9214949c52cc1eb33": {
+    "key": "f4435e801fd67d49b0dc39d50f4b05107b72901478d3a50103f64768ebaf7ede",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Chibiset1AnVino, chibi, girl, anime, cat, кот, Chibi Set • AnVino, telegram",
+    "nsfw": false
+},
+"722423d4a0186274fd4834e098a1652c": {
+    "key": "81cef8df29b0323d5d69facdd7b5696fdab9e4866339c14d1ff9dd80ef2a2c26",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Sergey, ChihuahuaChica, собака, животные, telegram, dogs, animals, Chihuahua Chica, telegram",
+    "nsfw": false
+},
+"e732da780ed070d6a2989a78749833de": {
+    "key": "74bec30d2e0ad9b827cd4cac934ade8b9bcb22acac33f19313d4af5142d2faba",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Chihuahuaji, dog, собака, животные, animals, Chihuahuaji, telegram",
+    "nsfw": false
+},
+"8e76573932ef13ff0066cd465d51faa3": {
+    "key": "08594d99f7ce435331deadbc6afee9592263658f4b022f64ee59508540740cf4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Chocolate_heh, chocolate, food, sweat, шоколад, еда, сладости, Chocolate, telegram",
+    "nsfw": false
+},
+"2c3a77289e107c444150c8faa962c61b": {
+    "key": "eb52e3d16adeb361fb447a070542b427871a7b197a4bed9df17eaf1ce2347075",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeriya Sikorskaya, ChristmasAngel, зима, рождество, новый год, праздник, winter, christmas, new year, holiday, telegram team, Christmas Angel, telegram",
+    "nsfw": false
+},
+"1de01153afd38bf17a5325beb2bc66c5": {
+    "key": "e1b45e562fec75ceb17b8a4fcbdce40730622ca8d55077716dadd6fa300ff85c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Viktoria Moloko, ChristmasGingy, telegram, новый год, рождество, печенье, еда, праздник, зима, имбирь, new year, christmas, cookies, food, holiday, winter, ginger, Gingy, telegram",
+    "nsfw": false
+},
+"c1c3427e7c2f6c6d35f70efb65e07575": {
+    "key": "9c92105d2079bb59690ca7e95769025d09ac458328a364ec595f208baf50c70a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Анна Шумская, ChristmasIrbis, зима, рождество, новый год, праздник, животные, барс, winter, christmas, new year, holiday, animals, leopard, telegram team, Irbis, telegram",
+    "nsfw": false
+},
+"182e2cf402b9ed319d257fa54d0dfb2c": {
+    "key": "d444495eed9f764d9014d3c8a192ac666d2b04a6c2c664e2579972479c0964ed",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Christmas_Elements, елка, елочная игрушка, шапка, санта клаус, снеговик, подарки, снежинки, новый год, печенье, украшения, Christmas tree, Christmas toy, hat, Santa Claus, snowman, gifts, snowflakes, new year, cookies, decorations, Christmas Elements (@RuTeleBot), telegram",
+    "nsfw": false
+},
+"08b141a91d80d2b2103fe03ef4891ab2": {
+    "key": "5efafe12b5e03ec3c8cac9cbd1c9a332ce6ebcfe32397cc8741834d338562d1a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Наталья Холод, Chuvstviki, animals, cats, коты, животные, Котики, telegram",
+    "nsfw": false
+},
+"2393ef99cab9fd9944746611fe431fc9": {
+    "key": "06e9f95925ccd3e8180b7048839857629eda8667a835ce02108ed69426343240",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "CinemaStars, кино, актеры, знаменитости, celebrities, actors, cinema, movie, FilmStars by Praga, telegram",
+    "nsfw": false
+},
+"c3f42e28439723c3ff152e9e01cc963d": {
+    "key": "cd8b87abcb0db89d81f22f816cbdc3473a6624bfcdc076649b3acee12344eb90",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Viktoria Moloko, ClassicCaptainAmerica, комиксы, марвел, marvel, comics, telegram team, 60‘s Captain America, telegram",
+    "nsfw": false
+},
+"d5fdeb9e2a374b9a381fc78a3fab3e57": {
+    "key": "971c7d9aaf6caccd7bed86563952fced893bba2f43ad971bc9fbc96ec84fc42c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ClassyWeather, погода, солнце, дождь, жара, лето, осень, зима, снеговик, солце, sun, winter, summer, ain, heat, autumn, Classy weather!, telegram",
+    "nsfw": false
+},
+"731a6bd2672cc2f5c19c0db3e2bdf320": {
+    "key": "be8377b7798791a522e262cb88b5079724e5a7fa1a3f59f2e475f2a8a73032dc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Cobik, кот, животные, белыйкот, фото, фотокотика, cat, animals, Coby The Cat, telegram",
+    "nsfw": false
+},
+"58c163f66e8fcba34bb4ab5ffe6e7107": {
+    "key": "9f6e84db6d6833d215414e5ba6d8ec801c17d5a0b1579b149478f067baf32da4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Cockatoo, попугай, птица, животные, bird, animals, parrot, Cockatoo, telegram",
+    "nsfw": false
+},
+"f2e9e722a932870d9d81a44f82fcc963": {
+    "key": "f7443677dbfbce814f36394e50abc7fc18f4d2ac57a1a0a1e07b4703f70c4e31",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ColdAffairs, животные, медведь, polar bear, animals, Cold Affairs, telegram",
+    "nsfw": false
+},
+"9ad7983583c7d7184788cb0959e39701": {
+    "key": "098e53ed99e4df860c7dda68c6b8593c5a159a0fee9d6aca566a61cbef595ba5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, ComeToTheDarkSide, новй год, зима, рождество, праздники, снег, елка, звездные войны, фильм, темная сторона, new year, winter, christmas, holidays, snow, tree, star wars, film, dark side, Darth Vader, telegram",
+    "nsfw": false
+},
+"1c010b3254577b93a3bde008a3378da2": {
+    "key": "957c3977dd78960448e5a28c168ad211eaf03d837fac64227152e2c1f9f03494",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, ComradeFox, лиса, животные, animals, fox, Comrade Fox, telegram",
+    "nsfw": false
+},
+"aa87d940d12d7d4c711c97e50923817d": {
+    "key": "14d04a6b1931245d23a77e5f4b4b5e810b3d9b57c1cac8e0ba8133d6a9848c57",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mari Inari, ConneryBond, джеймс бонд, james bond, фильм, movie, telegram team, Agent 007, telegram",
+    "nsfw": false
+},
+"0e623c1124f130e9ab637edd6e7204ac": {
+    "key": "94a2d5f9761fdd5c5b631743119182d07c15b89e72ed3fafec89f2034f91c499",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "CookieCatWafWaf, кот, животные, animals, cats, Котик Печенька от waf-waf, telegram",
+    "nsfw": false
+},
+"c44f5d30ca15d3d7c191adde55ae2fdf": {
+    "key": "7d6b80f3a634b122fedda7b1ba8e452a1f058370350ddb0a60b35c641610512d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Филинков, Cookie_AFilinkov, еда, печенье, вкусняшка, сладости, food, Сookie, telegram",
+    "nsfw": false
+},
+"156382df6bc4f38ed053d3ad97f1d5d2": {
+    "key": "c1eafcc714333429e17680378e47160c36ecf34967f373c16992ba45271bd38c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, CooperthePlatypus, животные, утконос, сарказм, sarcasm, Platypus, animals, Cooper the Platypus, telegram",
+    "nsfw": false
+},
+"a08d6bcf02adf29a247b84eeedcf86c6": {
+    "key": "7b011887034e4531aecf007dd45b7f61b682c83b36a53a88310fe1580db5c428",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Corgeous, животные, собаки, корги, corgi, dogs, animals, Corgeous, telegram",
+    "nsfw": false
+},
+"f930324bfa75486fb76fba073cdbef8f": {
+    "key": "dd25030c009be3068f65ffbf198950cb63cacf82e874875ae9baf2bcef1aa7b3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Daria, Corn_pap, кукуруза, еда, food, corn, Corn, telegram",
+    "nsfw": false
+},
+"ce880b5e819104d666cae1e32ffbc81f": {
+    "key": "6a0ac089f308ce531ee74433783f0b1f3f50fe7ec2d7a913c55baf16c90bdd63",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "CosplayGirl, косплей, люди, девочка, девушка, игры, костюмы, games, Cosplay, girls, peolle, Cosplay Girl, telegram",
+    "nsfw": false
+},
+"5bf30123de05fda9f9d39c4bfa80f6b5": {
+    "key": "f9b3e7a20ecdddbefed594ad2f4871a32183f250fc1f37be416cb927f7a232b5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, CowboyCactus, кактус, растения, природа, ковбой, лошадь, дикий запад, cactus, plants, nature, cowboy, horse, wild west, Cowboy Cactus, telegram",
+    "nsfw": false
+},
+"82b206bc7a2bfbaf1f216b67db6da230": {
+    "key": "8571857dd2197a6ce15875c3a455142e96466df3402693473c2d305ace09051e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, CowboyFox, запад, ковбой, вестрн, лис, животные, west, cowboy, wester, fox, animals, Cowboy Fox, telegram",
+    "nsfw": false
+},
+"04c053d91d272f907db090086aeeff66": {
+    "key": "8c21fd6a20cbfdb5c55538bb06819fefe640226260519f029e0c2f712f35200b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "CrazyPony, пони, лошадь, животные, pony, animals, horse, Crazy Pony, telegram",
+    "nsfw": false
+},
+"dd193057e93d511a2f1b3159bb242a6e": {
+    "key": "32bceefb200f45d2e64907dee9dabef80260d563823b625efffb9008cd55abed",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "CrazySnail, улитка, животные, animals, Snail, Snailo, telegram",
+    "nsfw": false
+},
+"64edf8d1f64ac179a903ef30f98e34c0": {
+    "key": "0a41751514a481c405c256856061c6be6b327603dbf47e9c79cd5d586b927911",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Alexander Scherbina, CrazySnowman, snow, winter, снеговик, зима, снег, Funny Snowman, telegram",
+    "nsfw": false
+},
+"a0b94282f7c537bb2dfc9a90d1b39112": {
+    "key": "6991ca2b0d3c290c127b58717020f45535f38ab6c17b6f307772b2bf4d68de51",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, CriminalRaccoon, криминал, бандит, животные, енот, наркотики, тюрьма, преступление, crime, bandit, animals, raccoon, drugs, prison, Criminal Raccoon, telegram",
+    "nsfw": false
+},
+"06dbab744de1ab34147889f4b969a56f": {
+    "key": "c2e2f7981a47c9fa4c8087d855acd88538ddac87e74342f7a247b628addb8a2b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "CrusaderElephantPepe, слон, pepe, frog, sadpepe, memes, funny, юмор, пепе, мемы, лягушка, животные, animals, Crusader Rare Elephant Pepe, telegram",
+    "nsfw": false
+},
+"c2c6d16212160c972c67df1920c9af67": {
+    "key": "ae4b0c43803e85d0fc54b922f2bd0eefbc18522110bc3de7f28380e8bf305b18",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, CryptoHamster, биткоин, криптовалюты, хомяк, животные, bitcoin, crypto-currencies, hamster, animals, Crypto Hamster, telegram",
+    "nsfw": false
+},
+"d0c3b21e76f6468163d21d4fb53f910b": {
+    "key": "580e7ba395b068c6a604e7628a947da8880d01e88ea68dc1c579155bc415b00c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Kirill Dmitriev, Ctulhu, лавкрафт, монстры, ктулху, Lovecraft, monsters, cthulhu, Ctulhu, telegram",
+    "nsfw": false
+},
+"2381d9581ff5085116b9ef1d9285bd47": {
+    "key": "fc32811e661755e53781d93e83c056267378ffa4950df5b4efd931d7ca361413",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, CupidCat, 14 февраля, день святого валентина, ангел, любовь, отношения, сердце, Valentine's Day, angel, love, relationship, heart, animals, кошка, животные, cat, киса, котенок, Cupid Cat, telegram",
+    "nsfw": false
+},
+"d674480ebbd67e4647109a86ad37d4c5": {
+    "key": "a39ae9a2006b2e616cc7f3d8196279918249717f4a9c1f10086621ec6c9cad3f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Sergey, CupidValentin, любовь, купидон, сердце, 14 февраля, день святого валентина, love, cupid, heart, february 14, valentine's day, telegram, angel, ангел, Cupid, telegram",
+    "nsfw": false
+},
+"1d7dffff400b9fb38979a340f13a4a14": {
+    "key": "653aaedeea8cbc2036fad83788ef144be4bf2855d61aea6c7346cb17a8b9f794",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valerie Fortuna, Cupida, любовь, купидон, сердце, 14 февраля, день святого валентина, девушка, ангел, блондинка, telegram, love, cupid, heart, february 14, valentine's day, girl, angel, blonde, Cupida, telegram",
+    "nsfw": false
+},
+"1d80ddb02e3cf5ae00a0291f7089806b": {
+    "key": "ca398d0c41d1852f2dd9945c8ec35fa17f8c7a89c0e90fe37eb8c04963956dd1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Curvy, люди, женщина, girls, women, Miss Curvy, telegram",
+    "nsfw": false
+},
+"7ba72c6180e1f705538171bed215b835": {
+    "key": "9fedfd7a0ca1f3a8ef0fe1b0127d41ca135bfc2cbf037aafeb13866def58443d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, CuteBunnyGirl, аниме, девочка, животные, кролик, заяц, anime, people, girls, animals, Cute Bunny Girl, telegram",
+    "nsfw": false
+},
+"90597904f7c0acd3b6cdcb86a1264e97": {
+    "key": "d938e0322302347180f037637ea0f4ea05cd52e11b35042101eabd9375bdd390",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, CuteCat_slangbang, слэнг, английский, slang, кот, животные, фразы, cat, animals, phrases, Cute cat by @slangbang, telegram",
+    "nsfw": false
+},
+"c4423f2d56db6b2c6c5b63d23e3f1786": {
+    "key": "fa04a5cfd683d76ecdadf5c73c126ef36b9f5cd4b03630c14f8624a7af06efa9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, CuteDogs_byAlexzhdanov, собаки, dog, dogs, мимишности, животные, Собаки и только Собаки @TuristasTV, telegram",
+    "nsfw": false
+},
+"72278605da381346615c63aaaa1050f3": {
+    "key": "80cac2a57d8ee460a3faffe5fe90ba7c8a264c20b26aff46e2092c8187155723",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "CutePou, поу, игры, games, Cute Pou, telegram",
+    "nsfw": false
+},
+"377adcd7292ee310afd6c42605dd7db0": {
+    "key": "81295091f45a3f4c6470d5c6783e8140abda7f0edbb3a4a0083551371a3f3045",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeria Fills, CuteUndyne, зомби, zombi, Андайн(@Valeria_Fills_art), telegram",
+    "nsfw": false
+},
+"851d36549688db6f1f10b10b1ad51c4b": {
+    "key": "213b6bfc101549e5d6f5a74b3ef7363d0db1333980283d9c9d2c7cf78387d20b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Наталья Ошестюк, CuteYeti_byAlisblack, снежный человек, зима, новый год, winter, new yar, Christmas, рождество, Cute Yeti, telegram",
+    "nsfw": false
+},
+"b5b08954b2450b834007929fe377e7c8": {
+    "key": "1ca4583661bfe604ae467f8304fefd2dc15540c6271476799a07d090ee1a4e0a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeria Fills, Cute_deer, олень, животные, animals, deer, Deer🌸(@Valeria_Fills_art), telegram",
+    "nsfw": false
+},
+"67cc054966ec3d05b4560c7400e362ce": {
+    "key": "7d79d6f5fca7889b9f955b10c8936a7d24badb8e9b3caa389817c1647d2d6d55",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeria Fills, Cute_fennec, лиса, животные, лис, fox, animals, Fennec (@Valeria_Fills_Art), telegram",
+    "nsfw": false
+},
+"d332bcd24f6af8fabf0c7c1a4274e1dd": {
+    "key": "0a8ba55cfcdea9fccb19e7d4a3da86fff60b47e88e60ed48042dfaa7968ea786",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Татьяна Андрущенко, Cutepumpkins, тыква, овощи, хеллоуин, pumpkin, vegetables, halloween, Cute pumpkins, telegram",
+    "nsfw": false
+},
+"81fd72b21d43fdfcd834ce8904bce8b7": {
+    "key": "b470a07e181c4432f4d840ff7f4fc7490307ffb52dd3270bb27065ebb5f9ab01",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "CuttheRope, игры, персонажи, ам-ням, games, cuttherope, gaming, Cut the Rope, telegram",
+    "nsfw": false
+},
+"6a4bd5d7f20c4e9163a4fa5d649c5b8a": {
+    "key": "416cc1b7a6bea0e36c50e6e35d3e0ded03f846e5024c7a12bc5165b0c019b5f3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, DCHAV, комикс, дс, супергерои, comics, ds, superheroes, DC, telegram",
+    "nsfw": false
+},
+"fc766a82c7b11cda726416f393a3d068": {
+    "key": "c9de983fe48ad8577f2e98959ae7795c7518269657e4d1741018cd16c2372c18",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "EeZee Stickers, DRAKE_4eeZee, музыка, рэп, music, rap, DRAKE @eeZee_4stickers, telegram",
+    "nsfw": false
+},
+"eb26cec5457c0b7db40d118aef6a47b5": {
+    "key": "8274e00cd29c6970fcbf73291683bdb30ac115576013bfc1622a91046e3529c7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "DachshundJones, животные, animals, собака, dogs, Dachshund Jones, telegram",
+    "nsfw": false
+},
+"aa5d2a0a646cdc9793002959b4395694": {
+    "key": "7415fba2ad7d55d105cb157d2d2e3471e1c944f09e6201370641683056ff6edd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Daenerys, игра престолов, фильм, сериал, актриса, зима близко, game of thrones, film, series, actress, Daenerys Targaryen, telegram",
+    "nsfw": false
+},
+"4d95aead94174a04351e6a1e7121db14": {
+    "key": "f838ede15ac08741aa621b0f9a080f0ea5cccee66b40b31aa40f6031823fe0f1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, DanceoftheVampires, вампиры, ужас, жесть, страх, надписи, рекомендации, Бал ВАМПИРОВ, telegram",
+    "nsfw": false
+},
+"14d3ef0c28e89e7d99fb9f0257b6bed1": {
+    "key": "fd291e163b2d6b9c7c31633e876440acafc3429cd76978d3c6ad3e4eaffdbc51",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Nightgrowler, DarkSoulsLordran, telegram, game, игра, Dark Souls, telegram",
+    "nsfw": false
+},
+"a36e102a35efd39302d99a17b9d55e67": {
+    "key": "647163e44aec676d1531120ae922f322ce37365bf773b0e821b297b03539b245",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Oksana Orlova, Dasha_Oksana, девочки, девушки, эмоции, друзья, дружба, girls, emotions, friends, friendship, Dasha&Oksana, telegram",
+    "nsfw": false
+},
+"31b6408aa4f37ddbd54f99d4ad0156b3": {
+    "key": "98c971aa90573c735b9d20fd7ef679e53e458c0d0d308f2b3c6ac13e190a6dbf",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Nataliya SILICH, DavidStarman, rock, music, рок, музыка, telegram team, David Bowie, telegram",
+    "nsfw": false
+},
+"d9045f12eb84eac2cf84eefe4b32e95d": {
+    "key": "50dba0386514367731255fb315830a5dc08e27e18c5514a6b3e6144eb0fd268e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, DearWolf, волк, животные, animals, wolf, Dear Wolf, telegram",
+    "nsfw": false
+},
+"adfa7c6af12f5d9a1d6c52bf86e35bf5": {
+    "key": "05aeef8f8a486d990fc6f450ae7ded53aa5366a694f20c09843dce7c61eed19a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Мари Zeligen, DemonMaze, демон, девушка, черт, demon, girl, hell, Demon Maze by @zeligen7, telegram",
+    "nsfw": false
+},
+"0eb1c3a88d8a96d85974d5fe642ec15c": {
+    "key": "658a83d3a23e87add46dae3c36c03da63046f4d425914ac02f8f1dfeea1ff4df",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, DemonsDay, хеллоуин, тыква, кладбище, страх, оружие, ужас, демон, Halloween, pumpkin, cemetery, fear, weapon, horror, demon, Demons Day, telegram",
+    "nsfw": false
+},
+"ee54654c0d073bd73b3db30c19bea64b": {
+    "key": "c2a25d03bd092818a5e7e61b401be6f24f330cffb6a347c4945f225fbf426aad",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Desperate_Housewives, сериалы, series, Desperate Housewives, telegram",
+    "nsfw": false
+},
+"808e4a017a9cc31308a8894158cdd4bc": {
+    "key": "976b7488efdb5bf67c95d99bce42d9979c8db1acd7d99d52f8a4025f986ab07b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Deviantc, crypto, coins, Deviant Coin, telegram",
+    "nsfw": false
+},
+"862469d78f8c269e64d3cf74a81719c4": {
+    "key": "eb430e716834eece4d6c084d78d7d808b86907478a508569d2f4bd951b8726bc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, DevilInYou, ужас, страх, дьявол, чёрт, Horror, fear, devil, hell, hellowin, хеллоувин, Devil In You, telegram",
+    "nsfw": false
+},
+"13bc3fe6e379b5d0dbcce3fe1a5b3320": {
+    "key": "19331d2b2881e2a47fc303c902adc100473950bb9ea9090ef059afec0c6a595e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Dibujandolosdias, comic, illustration, иллюстрации, жизнь, vida, life, Dibujando Los Días, telegram",
+    "nsfw": false
+},
+"03a39bc0af28252d340c698379586b82": {
+    "key": "bde14439888e4163fa2be4025de7823436f7fcb3e984d56a419a9a0089dde748",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Blueberryheart, DickyByBlueberryheart, монстр, monstor, член, хуй, секс, sex, Dicky by Blueberryheart, telegram",
+    "nsfw": false
+},
+"b50e9d5d744b84035ade79086edf278b": {
+    "key": "890522ad5c279473e2b52a18a9b1fa848728df13e20659ed1cf8cc9f6a7f7cc7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Den Cliff108, Die_Hard, фильм, movie, telegram, Die Hard, telegram",
+    "nsfw": false
+},
+"0d7f5974a9fbb3f8db2185c701770e7d": {
+    "key": "54c1c00ecedefe7dca87fa7ecb72210bcf3f5300955707a4aa483039d6a08469",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "MaksPV.stuff, Dinek, кот, животные, рыжийкот, Дынёк, telegram",
+    "nsfw": false
+},
+"86a935d72ef6182d86a32465f8546adf": {
+    "key": "5c6f219bb024b166724a9f45563dc1056c2cec78fa08300a71b96a19641ce02d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Aryvejd, Dino_Zluka, animals, dino, динозавр, животные, Zluka by Aryvejd, telegram",
+    "nsfw": false
+},
+"f931af77554043bcda9eeba610f4b903": {
+    "key": "bcca2142b0d4552b792424b0ef97f1750a5e72348b0f5c82c98dc365fbf0084a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Facebook, Dinos, животные, динозавры, dinosaurs, animals, Downer Dinos, telegram",
+    "nsfw": false
+},
+"82c0aef21f95aadcc838b09980605391": {
+    "key": "d149416869235065051fa69b3f9681e3e209ab4d8814728b24d0e16fab52abd2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Anna Kostiv, DocAndMarty, telegram, фильм, фантастика, кино, film, movies, fiction, Back to the Future, telegram",
+    "nsfw": false
+},
+"dc50d2b78667ec076dbe4ced3dc37134": {
+    "key": "48feec9c00f151b5f2bbf4d0fd4f9673b1dc62a796e51a54878c38ec90b9a808",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, DodgerTheKangaroo, животные, кенгуру, австралия, animals, kangaroos, australia, Mr. Kangaroo, telegram",
+    "nsfw": false
+},
+"831f88ddd77faead3fc25dfcb8ecf173": {
+    "key": "316531ae7ac845773a3e822a1cf18ad93e6193afee78bce1dd2195baac601b5f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Валерия V, Dog_Collection, животные, animals, dog, собака, щенок, конкурс2016, Dog it!, telegram",
+    "nsfw": false
+},
+"ba0a96da500e96c58eb3f1c3f377c4b2": {
+    "key": "6126cd00e932c81a577515062afdaa5e9d8425a8c966d12488d76c504d99ce03",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Anna Kostiv, DollarsTrilogy, фильм, запад, актер, вестрн, film, west, actor, western, telegram, Clint Eastwood, telegram",
+    "nsfw": false
+},
+"07fe19b10eb8bd257ea5bcaa1d1ceee1": {
+    "key": "4a435775df2f2fc53b8d2e4834e2bcaa11e5b791dfe63d4b8517f5681c28678b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Don_Corleone, Крёстный отец, The GodFather, фильмы, movie, Don Corleone, telegram",
+    "nsfw": false
+},
+"89b545bafcf224bfaeab9338e791d74e": {
+    "key": "c58f89fdcf0e08c81ed626aeac72e724dad38babddc53135dd3c0ab90e4635ea",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Snowy Jellyfish, DonaldAndDaisyDuck, telegram, мультик, дисней, птицы, утка, для детей, любовь, отношения, 14 февраля, день святого валентина, cartoon, disney, birds, duck, for kids, love, relationship, february 14, valentine's day, Donald and Daisy, telegram",
+    "nsfw": false
+},
+"b66bc2f676336e60ba4a96282b8664ab": {
+    "key": "62f1411036122cd00f0969347c8ad2bd0b79bb4a6f2fc1c77d3dc9deced2120b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valerii Matiukhin, DontJustFly, disney, слон, мультик, животные, длядетей, telegram, cartoons, elephant, animals, forkids, Dumbo, telegram",
+    "nsfw": false
+},
+"92e34e2317ca47641d2d0bbdbd22480a": {
+    "key": "e9b5ed2dd658cd8e09151bd88a4e8de294be4fc182d4c289c83376f2e03d6763",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, DonutAndCoffee, еда, сладости, шоколад, кофе, пончик, продукты, food, sweets, chocolate, coffee, donut, Donut and Coffee, telegram",
+    "nsfw": false
+},
+"0481dc228934e54b18c54bf475631f29": {
+    "key": "14cc175b32ef7949aa60e04185b9c2374eec1724d4c71f89453468aec1434c2c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Snowy Jellyfish, DrEvil, telegram, остин пауэрс, austin powers:, movie, фильм, Dr. Evil, telegram",
+    "nsfw": false
+},
+"b11b2b05a98f14aa345bffeaec99cce6": {
+    "key": "76f20616f9dbc41b57938097d53cef25d48f47575d0115965c6086919bbef66b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Drakulessa, хеллоуин, ужас, страх, дракула, кровь, Halloween, Horror, Fear, Dracula, Blood, вампир, Vampire, Drakulessa, telegram",
+    "nsfw": false
+},
+"24810bfc0cc26afe0bfa889684034beb": {
+    "key": "d2d133a16a34722de9cd0eb0353de53214a561712884fbd44ae84f9cb392218f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ding Ding, DramaLlama, animal, lama, лама, животные, Drama Llama, telegram",
+    "nsfw": false
+},
+"05de1e1b650fc7e223318d2e2c185138": {
+    "key": "a9e956492e5394ee28ba75a82b53792b6c7350332eb86c7d37441c3f53d0d1ee",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Redsmock, Drawlloween2019, halloween, хеллоуин, праздник, осень, Drawlloween2019 by Redsmock, telegram",
+    "nsfw": false
+},
+"745ad12ded1ac848f0d5f1a2ca23c2e7": {
+    "key": "f6250501bf0c9deaed31f077302c86e4dd83df780385c1c08d2b912868eb99ff",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Екатерина Аксенова, DrawuApp, art, искусство, DrawuApp, telegram",
+    "nsfw": false
+},
+"3873376c9f69b3a3f9c27016ff53ad9f": {
+    "key": "efa67640896bac0d5d33509ce7c06f8ea87d4c4ed4d86f5bd98a59a0479ca66a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valerii Matiukhin, DuckHuntDog, собака, животные, dog, animals, telegran team, nes, games, игры, Duck Hunt, telegram",
+    "nsfw": false
+},
+"1b1b0670bb297e0f24411256bb5f2905": {
+    "key": "9b6cc1757c8da7dd825763927b6001aa59afa0eb3dd3eb924a5283c6f24179a4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, DumpDumpling, животные, animals, вареник, тесто, Dumpling, telegram",
+    "nsfw": false
+},
+"35b43fe82c41fc7409abb9737571274e": {
+    "key": "9cc86e3dfced0d7d38b02cf702aebd69037129401dee6d7cdb1af62ac3f46bef",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Дмитрий Кононенко, DunnoontheMoon, длядетей, forkids, cartoon, мультик, Dunno, telegram",
+    "nsfw": false
+},
+"7854454147c40cbd926fe573b657ff60": {
+    "key": "cd8bb4403802cec8c2bc6e2e5baea91683cc1d9b2a1cfd73324c4933c40ff40a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "DurexPack, презервативы, дьюрекс, condoms, Durex Pack, telegram",
+    "nsfw": false
+},
+"ce0f180414f81a492edce4de06abdfcd": {
+    "key": "0dfba3a8ac84dab4c07901eeb88b117cf901101b90d80821ee92de830d734cc5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ERoberts, Нетакая, celebrities, girl, tv, Unfabulous, девушка, женщина, люди, people, Emma Roberts, telegram",
+    "nsfw": false
+},
+"65eba25e0b579b259c5dd938acca2ec6": {
+    "key": "e4c3eb2008a735cfce0071d52b3eb0627ea07119cfd21a03c725dfd85d62a7c6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Kiselmix, Edgeless, edgeless, криптовалюта, tomasdraksas, биткоин, crypto, money, деньги, бизнес, bitcoin, Edgeless, telegram",
+    "nsfw": false
+},
+"66e9de0cd284a31f91592a3ea4ef0dd8": {
+    "key": "9a183bfcb39c8f113a599a3108f3c06edea887f19657a3a772f42a8c410a915f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, EdwardSheeran, музыка, люди, звезды, Sheeran, telegram",
+    "nsfw": false
+},
+"1be7035646a1d8c6c3c7cb3d382ba209": {
+    "key": "960a99c6121496022b987cd47de33c4d5d0bc4674bbf84a0ad75166f919c8e9c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, ElfDobby, фильм, кино, гарри поттер, film, movie, harry potter, Dobby, telegram",
+    "nsfw": false
+},
+"5fcb68e17191541bddedde9b70343985": {
+    "key": "0ade58aaf7b36765a941098b0e194ed0d323fd96614b2ff8901d80c2e51f6435",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Elisey, животные, енот, raccoon, animals, Elisey, telegram",
+    "nsfw": false
+},
+"4d9fb0e0a7cb88bf289e86fc6f6ee8ce": {
+    "key": "7572458753f9a97c5665120c6aa74c76ee6ca542f184bd042d2ee8e53146e409",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, ElizabethSteampunk, девочка, женщина, стимпанк, girl, woman, steampunk, фантастика, искусство, fantasy, art, Elizabeth, telegram",
+    "nsfw": false
+},
+"3c8301f22a588785c3ad59f569b6a2a7": {
+    "key": "9246def62e5902281ad20bc51c32db7f7025f590b26809ff29278819b1697c36",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Aksana Meshcharakova, Elk_boris_christmas, животные, рождество, новый год, праздник, зима, лось, animals, christmas, new year, holiday, winter, moose, Elk_Boris_Christmas, telegram",
+    "nsfw": false
+},
+"ba842926313b294be94700e1f35d99a1": {
+    "key": "4b6c79484194ab66059f7129c2ba6e5b984a2735260bc82394955595580933bd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Анна Шумская, EltonHerculesJohn, музыка, певец, singer, music, telegram, Elton John, telegram",
+    "nsfw": false
+},
+"f0b0e38641070ac564440a78033c20d2": {
+    "key": "bbce46a239abe8aa4311cbc808892a167c1535515a50de2073ebce9726daff0b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mari Inari, ElvisKing, люди, музыка, звезды, знаменитость, people, music, stars, celebrity, telegram, Elvis Presley, telegram",
+    "nsfw": false
+},
+"d08b7997371170b51b76a301f30047d5": {
+    "key": "6ddbcf81dc156cc9c96e2b7079fd9a11aa27b467eb7dd3a03969e642c661e052",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mikhail Golub, Elvis_ByOsmer, donckey, осел, животые, animals, вконтакте, Elvis, telegram",
+    "nsfw": false
+},
+"2946d62ea7489853c0f978e8ca9fa351": {
+    "key": "110aa895c077c6dcb2fc7d4b2453d1251b3bbf41cfe8896eb399e27b5b15bb63",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "EmotionStickers, люди, эмоции, девушки, женщины, People, Emotions, telegram",
+    "nsfw": false
+},
+"e63bde5c1eb92a933ee3952b713a25f2": {
+    "key": "bfe2bc6aa3aaeed647115d25eb00cde0ffe399849e544fe3c48e5698e2f27346",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, English_First_FOX, english, fox, английский, животные, лиса, animals, English FOX @stickerus, telegram",
+    "nsfw": false
+},
+"690e194ad271a479a3631e25c8157a76": {
+    "key": "b6b483eac83ebd32c5f0d94d7ac023e2472f46c1c114365349fd05e95ce5371e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, English_First_Stickers, утка, животные, птицы, английский, надписи, duck, birds, animals, English First @stickerus, telegram",
+    "nsfw": false
+},
+"309bb53184d6cc52598d31bf95d09d81": {
+    "key": "e19f30df38a016e19c3e2caaaa71683d8427d09a60ab07be670481170435e41a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Astinomia, Eren_pinknose, аниме, anime, Eren, telegram",
+    "nsfw": false
+},
+"465463d8aa08db414cfbec5a9f791f45": {
+    "key": "65eb06d7e7122d5925900acbf39539eb6ebb7dadef690cdfdeb386b185566eea",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "AnzhelikaJoy, EvaRich, инстаграм, блог, девушка, блондика, girl, blond, instagram, blog, telegram, Eva Rich, telegram",
+    "nsfw": false
+},
+"0f3018f26b5979953b6478baccc026c4": {
+    "key": "3e6db18bdf517115ad9e1e80c266bbb55420b597cc5d5210418083b8a2701caf",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Анна Шумская, EvilFairy, telegramteam, фильм, черт, дьявол, женщина, брюнетка, movie, damn, devil, woman, brunette, Maleficent, telegram",
+    "nsfw": false
+},
+"b9f431d128297ca819547e7ab040efaa": {
+    "key": "036b3b9f63d4ff8477a9b94e3a5239b344ba7932b2f4bc2aed6eca63ae34355d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valya, EvilGenie, джин, мультик, магия, magic, cartoons, genie, telegram, зло, Evil Genie, telegram",
+    "nsfw": false
+},
+"dea992dbc049e6bdfd23a9635040873c": {
+    "key": "f4eab706d93519ece69715f2c480990b89402044d28f967e275c8a9183f462c6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Alexander Sorochinsky, EvilMinds, тираны, сталин, иван грозный, иуда, гитлер, hitler, Stalin, tyrants, Ivan the Terrible, Evil Minds, telegram",
+    "nsfw": false
+},
+"773cbf057139ec0df16f813f06892a3c": {
+    "key": "437b4476c1a0d6b66979c9a2f874abd9d4750fb4134bd89839dfa20b0e145055",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Veronika, ExoticCat, кот, животные, cat, animals, Exotic cat, telegram",
+    "nsfw": false
+},
+"b1bb7aca25df9b21c9bba8f8ad8fffc8": {
+    "key": "a8c75e1ba9f56b9edc7fa17c822780872ecbbbce3b631bd7018379cc04d773ec",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Veronika Vieyra, ExoticPoleStar, Pole dance, танцы, стриптиз, Exotic Pole Star, telegram",
+    "nsfw": false
+},
+"3922d7af6902853bb0717e3401c9e3ce": {
+    "key": "8c49350f62b0e0fac21cb5a39f5d189170614775ab40f2c770b6d01d8b8cbde0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "EeZee Stickers, FRY_4eeZee, futurama, cartoon, mem, FRY @eeZee_4stickers, telegram",
+    "nsfw": false
+},
+"e4e79c0d6d2d07d1ebfde5c181e4dbb2": {
+    "key": "91b9c6a941ef9014106bb42fcba86969544e1f6fb3b12e75dea72df21963751c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Владимир Чистиков, FTGDS, комикс, арт, рисунок, art, comics, FTGDStickers, telegram",
+    "nsfw": false
+},
+"3e785e9e0ba400c6ba3443c2913e9d98": {
+    "key": "26eb5062bc16238713b01c1c3fe8b0501d26c308dbac7d621814d067d93f8739",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "NTLENT, FanFriends, сериал, series, telegram, Friends, telegram",
+    "nsfw": false
+},
+"ba22ed0525649e4eba7c03b8795e88d1": {
+    "key": "935b350ce4f4a245a1e223bfebd256b48aa8776273aaf02acfc387bf9ccc45f2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "FattyYeti, снежный человек, snowmen, конкурс2016, Fatty Yeti, telegram",
+    "nsfw": false
+},
+"bb40e239028d4bd059204206c2df627b": {
+    "key": "38f027589fa2848b3a13ddddd593fade005be55449d8fcb76ee251830c579799",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, FedericoFellini, италия, кино, фильмы, режиссер, люди, italy, cinema, films, director, people, Federico Fellini, telegram",
+    "nsfw": false
+},
+"8df9f021becdb150e45c9572ff33ac48": {
+    "key": "2ba991b7fee5249be8745dc9025e7eb084fdbf2e38b0335e648587067ceda7cf",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mikhail Golub, Felix_By_Osmer, тигр, tiger, животные, animals, вконтакте, Felix, telegram",
+    "nsfw": false
+},
+"c6098d1d5876fb5c1029f00a655f00d3": {
+    "key": "91426d2a73ccad6661551c6c5998f5ad94c43aed68ddfdbc02f49ab6faf99474",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, FerdinandFox, лиса, животные, fox, animals, Ferdinand Fox, telegram",
+    "nsfw": false
+},
+"f95953aa787330b517411ab290f9acc2": {
+    "key": "55067e68a97bc2e3c40a87628e695836e0218358c6befc55609e4d0245a6e724",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "nizovatina, Filpiggy, животные, поросенок, свинья, pig, animals, Fil piggy, telegram",
+    "nsfw": false
+},
+"bd0048d6ac1a5f966632f58f905940ed": {
+    "key": "1e265722cbc6dfae25ff3b90513c484ef25c57fb535c6d46df459d8a2b58ab7b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "FinTab, криптовалюты, трейдер, биткоин, bitcoin, crypto, FinTab, telegram",
+    "nsfw": false
+},
+"9227c486fc561e5ac85cbb0e39f35f61": {
+    "key": "92b078ffcc44f9deca410a8e1864ceda046fc960fcb032ea3778615af925ed00",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Fingerface, finger, палец, Finger, telegram",
+    "nsfw": false
+},
+"30cc7361b45c91e9bc686fdf4b954555": {
+    "key": "5e129b94b1f8915f0f43e86d96ea5b9957e884a673f95125446dc0521121cc2d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Alina Nikolaeva, FlameHeadGirl, telegramteam, девушки, рыжая, girls, redhead, Hottie, telegram",
+    "nsfw": false
+},
+"f158cb38e29336b87f92c728c8460695": {
+    "key": "07bf65a67aa90a59ecbe3faf841572925c1d29ab4f65a855a40c84d76fce765a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Rileyy, FlipTilde, фурри, furri, Flip, telegram",
+    "nsfw": false
+},
+"469ef5829bc44093c9a4f445d5aad79a": {
+    "key": "e91914445ec45fd04f37a09daa31f33c115a3d65448621051f595000bbd526e0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mariia Furdei, FluffyBoo, монстрик, пушистик, monster, fluffy, Fluffy Boo, telegram",
+    "nsfw": false
+},
+"8d77f6db1becccbfdf34706d97fff0a2": {
+    "key": "803087ef530c9292b949669ca47ffe9c4fbb5a5ab9fa820df2e8fbd784359813",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ulyana_citer_art, FluffyFriendFurby, животные, пушистик, арт, art, animals, Fluffy Friend Furby    @ulyana_citer, telegram",
+    "nsfw": false
+},
+"b6393db61c6de814f6a67ec87359de33": {
+    "key": "87e5ba4b00ef2dc4672b593ac9035d047a2e771f78bf1935cfd9401397a10c3c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, FluffyLama, лама, животные, animals, lama, lamma, Lamalicious, telegram",
+    "nsfw": false
+},
+"9f9f248fd41e5831067e5eda99051cd2": {
+    "key": "e77972f8e8904cf0499af243ed6d537e7f7ab51f6f1534c84b56c0f3ef58a804",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Энди Нюрров, Flythecat, кот, animals, cat, животные, Котик Флай, telegram",
+    "nsfw": false
+},
+"00023f1aaadd1d946dc942180fe70766": {
+    "key": "e0cce5011c5b702f9cd826c40e95f7b6e8316ffaf218a144c86321f56e1bfae1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "FollowTheDream, мечта, путешествия, лето, туризм, summer, travel, dream, Следуй за мечтой, telegram",
+    "nsfw": false
+},
+"84b6c326bdf9872cc15f80f10b0d9717": {
+    "key": "38c3506af4bcf8a23604ab8af279f0813daee4434299a8c739e12e0ab3b5aa69",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Fomushkina Liza, Fomushkina, webarebears, icebear, bears, медведь, животные, белый медведь, icebear LizF, telegram",
+    "nsfw": false
+},
+"60f7774f365bbd7c7e8b2277cb12f605": {
+    "key": "33b57cee653f79d1121c1cdbfd4bfd4b68bf3126a8603cc1369aead99c312fc9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, Football_icons, футбол, чм2018, футболисты, карточки, знаки, мяч, football, россия, Футбольные Иконки @TuristasTV, telegram",
+    "nsfw": false
+},
+"8f4f484a83deefabe77bcd573ef1127a": {
+    "key": "1a8d1c2f2ab7917f08300e66822ff9fb8a7e7ec3e31cb8aee304f91a2ce76193",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ForeverCats, cats, animals, cute, Meowkers, telegram",
+    "nsfw": false
+},
+"b6ad85ba58740a96ebb5e87ba032bc26": {
+    "key": "6e1a3e7cc095f0805c58449691440bcc07c51cefdc7772bdba356d3619e44323",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "FrankTheUnicorn, животные, единороги, надписи, фразы, animales, unicorn, inscriptions, frank the unicorn, telegram",
+    "nsfw": false
+},
+"075a9b55958a55a91a427f9ef69d3254": {
+    "key": "56d44f62caa3b2c8f2500aa654005cb8bf3e2dd1efb9da7e80e4ae7db8ba06b7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ulyana Tkachenko, FreddysNightmares, хэллоуин, фрэдикрюгер, ужас, фильмы, telegram, movie, horror, halloween, Freddy Krueger, telegram",
+    "nsfw": false
+},
+"c9afef99267ed55452611c663c95f467": {
+    "key": "5cd0a83373b159ac8150ae2d41b59fb8d79b6fc2e6e42f3c21b7550671578ac6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, FreeOwl, сова, компьютер, работа, фриланс, удаленная работа, птицы, owl, computer, work, freelancing, remote work, birds, Freelance Owl, telegram",
+    "nsfw": false
+},
+"396a1f94b0c76567042aecb8b5fbc7c2": {
+    "key": "7fb9995692536a9b265db625ae2139f3ffff06f68169ebdcdff88bfea48558d1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Konstantin Brilevsky, Freefromcares, ленивец, животные, английский, sloth, animals, english, Free From Cares (@svbdn), telegram",
+    "nsfw": false
+},
+"e43b79e41253c45eb40a3c33e13c7488": {
+    "key": "3926d1917e35065a14d3ae8eb3bbd6d514b6e4203c1d3a4d99b9783710330387",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valerii Matiukhin, Friday_The_13th, telegram team, пятница, 13-е, friday, the 13th, movie, фильм, ужас, маньяк, убийца, killer, maniac, horror, halloween, Jason Voorhees, telegram",
+    "nsfw": false
+},
+"c7614e8ecb57cf0dad518c1be34537fb": {
+    "key": "93a17f06689163feb3faffa7ffe0777590802de6637abb44526dfb7772c6f1e0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Konstantin Brilevsky, FriendlyDeath, смерть, скелет, коса, ужас, Death, skeleton, braid, horror, Friendly Death, telegram",
+    "nsfw": false
+},
+"aebe3e52ebec05ce51a67a4e723bb97e": {
+    "key": "b4fd505309bf6a9dec8ea853a4b0a94dd2d398f89c76ef8ed613a4135075db15",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "КиноСтикеры, Frozen_2013, мультик, cartoon, Холодное сердце ::    @animesticks, telegram",
+    "nsfw": false
+},
+"a9bb87989a49c0f02c08ce47bfbb8c51": {
+    "key": "831e0dfa7ffe46ac49e2a40f16c6f5c934b94db1f6dd5c2ff2043dc898c6425f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "FunnyCats64, котики, коты, животные, фото, юмор, cats, animals, Funny Cats (@Saratov64_chat), telegram",
+    "nsfw": false
+},
+"dcbe67469f041e5957a269cb2385f4a2": {
+    "key": "664a68e790855ffbfd04798863e9ed292ee6b0f0d8bcffd53ce7dd4b38fc26b2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Дарья Огнева, FunnyFox, животные, animals, лиса, рыжая, смешная, fox, конкурс2016, Ticky the Fox, telegram",
+    "nsfw": false
+},
+"cb646e7939c81730207d8515edfa2aaf": {
+    "key": "495e99dc7070830461b175f706a0a0273516692d2a4081a0d50328c87e18dabd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Виктор Костенко, Funny_Panda_App, панда, animals, животные, Funny Panda - @StickerManya, telegram",
+    "nsfw": false
+},
+"9210574736f815c3444af90a623191b0": {
+    "key": "cc86bdd34b6557076571311cec8e57fe3e349921ac33400dea51b9f78ce5f35a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "GOTsticker, сериал, tv, game of thrones, HBO, snow, tyrion, Game of Thrones, telegram",
+    "nsfw": false
+},
+"ea93cd4e3d3a0a30ed46800dbac10c83": {
+    "key": "f89c77b062db3e257e13f7f65be85509f9d305d7942d559bf138c6e98f396e4e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Tamara Gerasun, Gabe_Newell, programmong, программирование, люди, техологии, ит, it, telegram, Gabe Newell, telegram",
+    "nsfw": false
+},
+"ee1c2148095bf8bf4dbbaf9c9028e9e8": {
+    "key": "1cb43a0fee87434b1f9bc6d442fbbc36e59c9696e52f12143fb79ee2830b4d2f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Nightgrowler, GameOfThronesColor, сериал, series, telegram, Game of Thrones, telegram",
+    "nsfw": false
+},
+"3941289da549f85e637867ccd0b8c34b": {
+    "key": "eb1a6260a2459ce1b8d0810abd6c78b81428dd4542dca56cff9ddbe2e4ff7805",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeriya Sikorskaya, GameZelda, games, telegram, игры, The Legend of Zelda, telegram",
+    "nsfw": false
+},
+"99d258a41cc8e50a9ab7735255850a38": {
+    "key": "77681358939fa149ea01c7b422a58ef5d0aaf8ad41f8c6abdbb8c156fc958f9a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valerie Fortuna, GameofThrones, telegram, series, сериал, зима близко, 8 сезон, Game of Thrones, telegram",
+    "nsfw": false
+},
+"f4c4df98c91bfe5659125f095f2cd478": {
+    "key": "f324369648e8b44ac7fd591d77335dc027c1b9bed2c98f5d3ff147683701aff0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Марина Круглякова, Gamzee_by_rishka, homestuck, gamzee, makara, troll, highbloo, троль, Gamzee by Rishka, telegram",
+    "nsfw": false
+},
+"8c5af18e34c38ff2a158f31dc1050cd1": {
+    "key": "8c73bd4b08fc3053d78d7608b5ebb190ca965a8328c3a52902d0dbf16e49a01f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Garfielde, кот, животные, мультик, фильм, для детей, children, kids, cats, animals, cartoon, movie, Garfield, telegram",
+    "nsfw": false
+},
+"532c8c4a66eef92188834f7a1f03417e": {
+    "key": "4c800777697e4c39f6557c840c4dc209ec764e34cb567caaed0fc7a98ea94b02",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "TuristasTV, GayRainbowStickers, гей, лгбт, gay, жданов, Very Very GAY @TuristasTV, telegram",
+    "nsfw": false
+},
+"184d071d8fafbe5f54cabd4af6aebacb": {
+    "key": "3709a23eb6b0eb75faca8a65718e98e1a12180e941d408f25ef6d12a56dd4fa6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "BoggartOwl, Genieous, джин, алладин, alladin, cartoon, forkids, мультик, лампа, telegram team, Genie-ous, telegram",
+    "nsfw": false
+},
+"a1da9a1d32cc93e2c610290b634073f1": {
+    "key": "80789aed19334c739bec0a52e8958de6dbe97dd489e6ed4bd23aab6660fa41fa",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "KrisKaspi, GentleRabbit, кролик, животные, animals, rabbit, telegram team, Gentle Rabbit, telegram",
+    "nsfw": false
+},
+"b765c8fc4dd45b9bf2af4da2ab11fc54": {
+    "key": "08f1d2d72d87340fa519269b9a4047c51b9d0bd4b828a31f12e38ad82f879663",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Рута Михеева, GentlemanHorse, животные, конь, лошадь, animals, Gentleman Horse, telegram",
+    "nsfw": false
+},
+"83431f87c06e5b5807d7a0978bbcac28": {
+    "key": "a37ebca5b2e976724fc86323fbf68a49ee9526444be79edbf2178b4f157a922a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "GeorgeTheElk, олень, животные, лось, deer, elk, animals, Elk George, telegram",
+    "nsfw": false
+},
+"da5acfc9d4e8aa7838bf4858a86e091e": {
+    "key": "267dc801a9afaaa40e3b49d50ae3b55ffec62438de24bc3a548d10d0e76c9214",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "GiraffeJan, giraffe, жираф, животные, animals, Жираф Жан Giraffe Jan, telegram",
+    "nsfw": false
+},
+"86d8b6e66d49951e930be7d56026e954": {
+    "key": "455ed927fa3db2ad5e5d8303a5292ce07807368dd4ac2fe33ce4bb54ed8f2ce3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mary Ka, GirlLovesBooks, книги, литература, чтение, books, Girl Loves Books @duosoft_books, telegram",
+    "nsfw": false
+},
+"4c24defcefe49f43554d33586fa816a6": {
+    "key": "f8e0bc1aab318958a41d63d6b92c5435af454786750c89ccadcca1bfc0e3a8f2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "GirlyFoxR, fox, animals, животные, лиса, лайн, line, Girly Fox Remastered, telegram",
+    "nsfw": false
+},
+"8c02c28f09cb914675e90dde5438bf04": {
+    "key": "8cdd1523ece7604fb0525a660904564fb89f58fab6f2bfc973a0b6ff0b93f8d4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Carolina Dargel, GlamourPuss, telegram team, рыжая, девушка, мода, гламур, чика, red, girl, fashion, glamor, Glamour Puss🔥, telegram",
+    "nsfw": false
+},
+"6604e0ffb13353383dca586dc894b04f": {
+    "key": "9678da43ef57898af359377e94cb9a1bd3342859a6182108b29fbbbb6aa7ee2d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, GoFox, лиса, животные, fox, animals, Go, Fox!, telegram",
+    "nsfw": false
+},
+"11410cc625c8131970d28f1dfb53df8f": {
+    "key": "e588fd45da610f60a30dbe0a2da0c33bad4b997dd7c03d2640a131bd1b40fab4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, GoRobot, робот, люди, people, robot, техника, equipment, Go Robot, telegram",
+    "nsfw": false
+},
+"c8142c11f0be13bb0a4371f9fcf7efc2": {
+    "key": "94f1010047ba33a7f48f2ffdc04fd9d065082b191587055fcbdfbfbfbd41678f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "AMEDIATEKA, GoTvk, сериал, tv, Game Of Thrones, snow, tyrion, сноу, фильмы, вконтакте, Game Of Thrones, telegram",
+    "nsfw": false
+},
+"306b39dcdd57300326c9a1a53d63acc7": {
+    "key": "c8499bd2e2c223632a1c063d3012b795a0766584809c02d03cef210b4bd64745",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Goddesssheep, овца, животные, sheep, animals, Boginya, telegram",
+    "nsfw": false
+},
+"cd258507e29f11eddf9f9f194b61e9b9": {
+    "key": "a11b3635fcca9d21657af503ff25d895fd99c4eeaf118bc2fc254580170fa3ab",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Boggart Owl, GoldamnFish, рыба, море, fish, sea, telegram, Gold Fish, telegram",
+    "nsfw": false
+},
+"260bf150f3706e77dd4ecacdfc1a1227": {
+    "key": "2332e1551f6c80df2a40674f258b76801151d8c7677b8776f4b3eaab3e66cff4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valerie Fortuna, GoldfishLady, девушки, girls, рыбка, fish, блондинка, blond, telegramteam, Goldfish Lady 🔱, telegram",
+    "nsfw": false
+},
+"a02148df6d1a00028b323e459880311b": {
+    "key": "a246764bcd380ae79b72b943a2e67e3d7c205127ebe2fe73bb2cf516d7864b29",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, GoodPuss, женщина, человек, кошка, животные, woman, man, cat, animals, Catwoman ::TgSticker, telegram",
+    "nsfw": false
+},
+"6b0d1a7b5715eaadde2eaba724a420ce": {
+    "key": "d8f622c91f42dea0fa63d3f8a635b63866a42729e8abdccc18ab0f1ab2d6997e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Goosanan, банан, еда, гусь, птица, животные, banana, food, goose, poultry, animals, Goosanan, telegram",
+    "nsfw": false
+},
+"f9db432e0e6012f6d3e06e94e02a4fce": {
+    "key": "c902d05f40c5cd71a0a0f8aa171d040de4918cb2eda483b656065e19c8ee2ade",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, GorgonMedusa, медуза, горгона, медуза горгона, gorgon, Medusa, girl, девушка, Medusa, telegram",
+    "nsfw": false
+},
+"5414003620f94237843dd285d99f5fa0": {
+    "key": "dd26f21aeacd0f0053a0a712de6212ebff8d1019e64a50df402d74c3bfed5aaf",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valerie Fortuna, GoslingR, люди, актеры, звезды, people, actors, stars, telegram, Ryan Gosling, telegram",
+    "nsfw": false
+},
+"68bce54cb69565485dc962f75dbefea6": {
+    "key": "a3e7c16c0e0dfeb2b3baa369274845c3a3754c88db5e5bb8804ee9d625d58a84",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Анна Шумская, GrandInquisitor, инквизиции, средневековье, испания, жестокость, inquisition, middle ages, spain, cruelty, Inquisitor, telegram",
+    "nsfw": false
+},
+"e300609161f77b431cd1d3ba6a94adbe": {
+    "key": "19ad31635deede4a5b3150402d37bc7c29eca3759e81d79fd3a1388d3a177d3a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Nightgrowler, GreatMindsColor, знаменитости, люди, писатели, ученые, гении, фрейд, эдгар по, цезарь, мерлин монро, коко шанель, эйнштейн, шекспир, клеопатра, telegram, celebrities, people, writers, scientists, geniuses, freud, edgar po, caesar, merlin monroe, coco chanel, einstein, shakespeare, cleopatra, Great Minds, telegram",
+    "nsfw": false
+},
+"e36fdfa0ba58bad44db95627819665db": {
+    "key": "0f69bc2022797327f6341c8f339eb7656989230776e2f71b7d25ea67f8a9c6bf",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Arakviel, Great_kakasha, poop, какашка, Радиоактивная Какаша, telegram",
+    "nsfw": false
+},
+"1bd3cbb77b281c437d9bb8c37817e214": {
+    "key": "8d98c61c88e23778d8b0ac31a5c6cc9093b82ff10c4cc46381bf3cc3b6dea7fe",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeria Fills, Grifoni, животные, милота, cute, animals, Грифончик (@Valeria_Fills_art), telegram",
+    "nsfw": false
+},
+"ddf071853c6ebf601c164fda9182bf0f": {
+    "key": "66c94ac8cb6eb0c84c2c8954335f6fb356d6a6a0c5ba374d3dc9dce79558e1ee",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, GrinchStoleChristmas, гринч похетитель рождества, Grinch Stole Christmas, новый год, дед мороз, рождество, праздник, зима, подарки, снег, new Year, Christmas, celebration, Santa Claus, winter, gifts, snow, Grinch, telegram",
+    "nsfw": false
+},
+"d9a2f18077406571dfc6d52b29599dc2": {
+    "key": "9a3ccdcc1f0589f588ba9cfc4563b5668121aab8e27e1c3e241f365fc8f490c3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Fomushkina Liza, Grizz_LizF, медведь, животные, animals, bear, Grizz LizF, telegram",
+    "nsfw": false
+},
+"d43b50949fd1ad579c5f006a65607511": {
+    "key": "fd3ca501058014378bbccb81680d3cf85819b6cc73e089f93f9a8393c31e0a43",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Serbun, GrungeIsDead, telegram team, певец, люди, знаменитости, singer, people, celebrities, Kurt Cobain, telegram",
+    "nsfw": false
+},
+"2b600a6385526e0047f0dbddea895e20": {
+    "key": "1624da7f37a9171d2fbbad1fa778c6ad34b601cb7c6b6a9a62e975a13cb3be77",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Gudetamasvik, желток, яйцо, еда, yolk, food, egg, Gudetama for Svikipiki, telegram",
+    "nsfw": false
+},
+"d443c8e68df6b3a61b8df10cf35ad7f2": {
+    "key": "db91eeb08e17093822a562f1e6732e264dcca98edb9bcdd2e52ab0b14d4eab6f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, GuidoFawkes, дворянин, католик, англия, люди, Nobleman, Catholic, england, people, Guy Fawkes, telegram",
+    "nsfw": false
+},
+"54a98bc576604d56293f7f3bb664204e": {
+    "key": "78c28a0870461b50adafe2f176886d45c1074702ae32dbab4be31cb16870371d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Gyaru, япония, девочка, japan, girl, девушка, мода, диета, Gyaru, telegram",
+    "nsfw": false
+},
+"f028f6a1e3353e2305bcdfd303238e41": {
+    "key": "2cb207a932854b9b3f8d4478608d20808a2fc1a65c2c3a6db01f5b01bbac632e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Hahaski, собаки, животные, хаски, dog, animals, Хахаскі, telegram",
+    "nsfw": false
+},
+"64416dc2fd4f81008030cea7be607730": {
+    "key": "cc075fd6ee2fcc436d6fc8d3cfcf0a12f2689180f6966e61b55f7b3578676ce5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Alexander Scherbina, HallowMemes, тыква, pumpkin, хуллоуин, halloween, мемы, memes, HalloweenMemes, telegram",
+    "nsfw": false
+},
+"21678bbb069a7809190c5993edc5b3ed": {
+    "key": "c453d2b25264731dfec95ba4f59300f09714a7c628fbc613fd530fc1fea2c32e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "HalloweenAndJ, тыква, хеллоуин, ужас, дьявол, ведьма, terror, pumpkin, Halloween• angelinaangry, telegram",
+    "nsfw": false
+},
+"207618f719a509195d5b66dd6646e124": {
+    "key": "830985a9853a3f6da174337a5053f4b06c39f39536b6616c712a9676592d2d52",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "КиноСтикеры, Halloween_1, тыква, pumpkin, Хэллоуин :: @animesticks, telegram",
+    "nsfw": false
+},
+"9f117460ab4ba5b1402c93cb0dfccd9e": {
+    "key": "7ec517f4d76c3c6a8e702a729dbd7d2016820f18acb20193c143928bcee9be7d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Hands_by_Oybek, руки, hands, \"Hands\" by Oybek, telegram",
+    "nsfw": false
+},
+"026bc96269dc17002b770661b591fcae": {
+    "key": "40c280e35e32a0cf505ce188d1bdc4928df2f38e1064efe465fe20c0982ba64c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Hangouts_Penguins, животные, милота, любовь, дружба, penguins, love, friendship, holiday, winter, Penguins, telegram",
+    "nsfw": false
+},
+"e4a5bb469a35d228b93231239be1c3c9": {
+    "key": "811d137e28390ae86dda6677a73a04c9e3e2cff7feec379fd42617aa15c927c6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Happy_Lumpy, happy tree friends, мультик, олень, живтные, animals, cartoon, Lumpy 1.1, telegram",
+    "nsfw": false
+},
+"20874043fefe87a0cdc9400f18b9f04c": {
+    "key": "8794daa2f2e434681ea1cf4c7f0765829dd585ac64aedaf7fa1c60bea43c8978",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Стикеры @artrarium, Hedgehog_artrarium, животные, ёж, animals, hedgehog, Hedgehog @artrarium, telegram",
+    "nsfw": false
+},
+"86d717ec10ebc7285ec23ee0e7426ebd": {
+    "key": "027880bf697255c4da17c38825d94a1db1b6485e28b8446abb975e3677dec6dd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, HerculesHero, геркулес, древняя греция, афины, миф, бог, сила, Hercules, Ancient Greece, Athens, Myth, God, Power, Hercules, telegram",
+    "nsfw": false
+},
+"29ae496ff0eaf5530e229dc3d712ae00": {
+    "key": "aeb0e8d64ac4dd95baa4812f05250e6858828e635f094892734ac9a418740c63",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, HeroesOverwatch, игры, games, overwatch, angel, genji, roadhog, zarya, mercy, Overwatch, telegram",
+    "nsfw": false
+},
+"929761726ec643694be2d646c435a79c": {
+    "key": "24e26eb5896fc6a1d3203151cee1dd8e0f82e6eb9c02fe7cff0ad01106bba1db",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Higejmt, собака, animals, животные, dogs, Higejmt, telegram",
+    "nsfw": false
+},
+"02e65e578659d8078354c8d0401e04a0": {
+    "key": "3d4d74c62c1a409f23abb1f1f76ff4a22c8dd44e9599cf322dc68ada94beac32",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Dima E, HillbillyDolly, древенщина, sheep, animals, telegram team, овца, животные, пиво, beer, Hillbilly Dolly (@TrendingStickers), telegram",
+    "nsfw": false
+},
+"7812c7156c408a7721d8e43066918b87": {
+    "key": "1022de3f7ec692b3dda522cde181cb63c0d8da67d6105de2bccebe6e15e8e310",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, HisDudeness, dude, чувак, фильм, movie, The Dude, telegram",
+    "nsfw": false
+},
+"fd960c914fe958ce8d058e4631973c9f": {
+    "key": "7db94806739c37244efeb7ff9c0f54fcad12ee04dd46b7875bac3a2b30e6d5b8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, HomeAloneChristmas, дед мороз, новый год, рождество, зима, праздники, подарки, один дома, фильм, grandfather frost, new year, christmas, winter, holidays, gifts, one at home, film, Home Alone, telegram",
+    "nsfw": false
+},
+"1a535d6a5f0daad8056523a7321931b4": {
+    "key": "90de81988dd74cc920baa2f1b02b5a9a7140bfda95702a11bc76fa61dd75e8d8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "HomerStickers, симпсоны, TV, Comic, Cartoon, мультик, желтые, гомер, Simpsons, yellow, сериал, Homer Simpson, telegram",
+    "nsfw": false
+},
+"796c9d097728772b4a8fc777b6089418": {
+    "key": "536c544db958bb3d84528ec28777c7b6e1004c958abc5346c240712573284289",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Darya Ogneva, Homer_Jay_Simpson, telegram, cartoon, series, simpsons, симпсоны, мультик, мультсериал, Homer Simpson, telegram",
+    "nsfw": false
+},
+"bd26b86c9f588f5ca223a4dc83683ac5": {
+    "key": "e225629de8f8a0cd3d158095455bb1229a79337e70c2ae94b155ade8812189f0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Екатерина Сторожук, Horsestick, конь, животные, сериал, мультик, нетфликс, horse, animals, series, cartoon, netflix, BoJack, telegram",
+    "nsfw": false
+},
+"7355660b17a3ab20d55d786d8987e1ec": {
+    "key": "06bfabbe9d92b2f28a2b27dd28c8e923ab3a5a302c64e8730e1032b4d772b642",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeriya Sikorskaya, HowardLovecraft, ужас, ужастик, писатель, мистика, ктулху, хэллоуин, люди, horror, writer, mystic, cthulhu, halloween, people, telegram, H. P. Lovecraft, telegram",
+    "nsfw": false
+},
+"cc54e4845080e7ddc1143e1542f40026": {
+    "key": "2aa8daca204a9ee5b88367a65fd3d11078cf3b2f82106422b503af6cba65bb89",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Howard Loves Craft, HowardLovesCraft, ужас, писатель, люди, монстр, лавкрафт, пиво, horror, whriter, monster, beer, people, lovecraft, Howard Loves Craft, telegram",
+    "nsfw": false
+},
+"7e9ae48cdf942d709b162ad7d826c3e2": {
+    "key": "595f5b1297f8a0d1fce65e61a0bb525dea917b77803c8d16a6c1b2716098240c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Sara Mauri, Humpy, кит, животные, море, whale, animals, sea, Humpy, telegram",
+    "nsfw": false
+},
+"c520102404675e8a082c4dabc1f44c46": {
+    "key": "5176fabc6c614ada881686de5880aae05b252f35ec504f2ceee80a72d0f0ab6c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "HuskCool, хаски, собака, животные, dogs, animals, Husko, telegram",
+    "nsfw": false
+},
+"5d1c8bcdd1c0f254f4956a60c0f83a5d": {
+    "key": "08b8e6d69aa7212e9b4dc2842203432acbf08a36ac06769033153c70ca94af06",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "HuskyBoy, хаски, животные, собаки, dogs, animals, husky, Hank the Husky, telegram",
+    "nsfw": false
+},
+"75d8ca9ac632b177624661655b7974f0": {
+    "key": "78dd1376d5987f95c631fa8753c83fa9c2467ae8e5f191ab040f2ae66c156512",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Alena Fyon, Huskyun, собака, животные, dog, animals, Husky, telegram",
+    "nsfw": false
+},
+"7f8871d476dfcf5ad53b04c9a4b9fb63": {
+    "key": "4c048146c2fde32b89fd51f36b5b7cdfb9ed33a7f795a96f79a8095f1afbdab6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "St?sik?, Hussie, telegram team, собаки, жтвотные, хаски, dogs, chicken, husky, Hussie Goodboy, telegram",
+    "nsfw": false
+},
+"02b5dc9aa4cc8ea7da1902134f53e921": {
+    "key": "ac7aaee355bb18afed55defc47ae80e2afc48d8e1fc72773e9dc889a3c4208cf",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "HyperFace, девушка, эмоции, emotions, girls, Hyper Face, telegram",
+    "nsfw": false
+},
+"e224c6ca66a59af4a95e762a248e4b99": {
+    "key": "6edcac43f106c449622f3ee7060baf44d005ad5ada3737d3690a51c7b40c132b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Viktoria Moloko, InTheShadows, ужас, хеллоуин, фильм, telegram, hellowin, movie, What We Do in the Shadows, telegram",
+    "nsfw": false
+},
+"a9e63851596f153b09d6062e34753b42": {
+    "key": "3f867858d427f07f58ef567f2fb87a50585c7ce78c8552d91d8da03f352e116a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Serbun, IncredibleStan, telegramteam, marvel, марвел, комикс, comics, писатель, Stan Lee, telegram",
+    "nsfw": false
+},
+"7661125a46e3a958425f1bcb0ee14a2c": {
+    "key": "4300961926ce72d66f2eb123a4521a0646939a9b4acf3287f558945d167a0cd0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Andrey Pryvalov, InsaneDove, telegram, birds, animals, dove, голубь, птицы, животные, псих, Insane Dove, telegram",
+    "nsfw": false
+},
+"d98933f6f2ac882787680a55e51b977c": {
+    "key": "d0258c80afd1926e46ae0286c2ab4936596f2e559c67f9226d2f8b0c80410ec0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, Internationalfootballstars2, футбол, football, футболисты, чм2018, чемпионатмира2018, месси, акинфеев, рональдо, Футболисты Мира @TuristasTV, telegram",
+    "nsfw": false
+},
+"2792fddcdf17896e73f615a9aa2c2895": {
+    "key": "df8924adcbce7ecd9cb6e3f81ea6d63b6e374045b4ccd037e6ac7715ed0c4ddb",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Aquamine, InternetAddiction, интернет, телефон, соцсети, компьютер, технологии, coputer, internet, telegram team, Internet Addiction, telegram",
+    "nsfw": false
+},
+"4ff01e1e9ccb0535e2a379c415ca8538": {
+    "key": "993ae710ae6eeda104c87ce63fa923b1e250f231125779bb8a4e6d4f04d734c4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "JEvents_Jewish_Stickers, евреи, израиль, ханука, Hanukkah, Jews, Jewish Stickers by JEvents, telegram",
+    "nsfw": false
+},
+"dd988510deac3a42bb91e8cf3b44f65d": {
+    "key": "cc6c10de6665b6b2c37cbce6fcf658222efb878d7c46e142fd9470b3e9146361",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, JackPumpkinHead, тыква, голова, страна оз, мультик, сказка, хеллоуин, pumpkin, head, country of oz, cartoon, fairy tale, halloween, Jack Pumpkin Head, telegram",
+    "nsfw": false
+},
+"9a0c105af0b2919f75b382cb230a0f0b": {
+    "key": "287e76ba3f1fdbcef7174d42e176563e75867f600c0485083d0d84d5e810fbb5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, JackandSally, telegram, horror, cartoom, helloween, хеллоуин, мультик, ужас, The Nightmare Before Christmas, telegram",
+    "nsfw": false
+},
+"78b546dd4a9659e2be35d676c0a6baad": {
+    "key": "209ddafbca36fca9ad9db8d8980b8097f1d3c961c0e47d1064881aa3bcd58c7e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, JapaneseKitty, кошка, животные, animals, cats, Японская Кошечка @TuristasTV, telegram",
+    "nsfw": false
+},
+"0a3e20fe50585f48d20fdc8397258605": {
+    "key": "d520ba06162e9b2b79e3b8fb6be2bc9ef9fa8a3176aee868e45878345caa18e5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "anna shaggy, Jason_Funderburker, telegram, по ту сторону изгороди, over the garden wall, cartoon, series, мультик, мультсериал, животные, жаба, лягушка, frog, toad, animals, Jason Funderburker, telegram",
+    "nsfw": false
+},
+"02f1ab0862b7ff4f5bf3d4d5a6877290": {
+    "key": "2ab5ed0e3e4e441f449e0a1e055b3a64b1ede9af74089fa5058dc2fcf82b92c9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Jaspurr, кот, животные, кошка, cats, animals, Jaspurr, telegram",
+    "nsfw": false
+},
+"3ec919028b99098a6f481889b188227c": {
+    "key": "285b02f1af84d093f483078e4cad56f9edd86df51170bb68a59ea1ccbb3be428",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, JeanBaptistePlagouille, животные, доктор, птица, ворона, зло, animals, birds, telegram, doctor, evil, crow, Jean Baptiste Plagouille, telegram",
+    "nsfw": false
+},
+"538c6149561b010204a15b51e6e8211f": {
+    "key": "bf82e43ee095d2b4654be41ec61a0041031ac93611942f0d8a03cbb5548982ef",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, JeanBaptistePlagouille2, чума, доктор, средневековье, plague, doctor, Jean Baptiste Plagouille 2, telegram",
+    "nsfw": false
+},
+"6c2349ac076650d355fb56e2e141cfca": {
+    "key": "d9d43daec5f1eae493882e02e3d874f8a3a06605ec25751481148f657cdcff95",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Sergey, JeanJacques, голубь, птицы, pigeon, dove, birds, telegram team, Jean Jacques, telegram",
+    "nsfw": false
+},
+"f8c4d87054ce1d72fe46836ee7e28161": {
+    "key": "13921cf1d7123911867d791629e9368318a4bb70f15b06ce663b0de463498432",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, JediMasterYoda, star wars, звездные войны, фильм, movie, Master Yoda, telegram",
+    "nsfw": false
+},
+"43da9cab23564f785484963acce243f8": {
+    "key": "94ea2c4eb05ce4fa94594ebf399fe4039f720f89cbd14e5302500380120d0cd8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Nataliya SILICH, Jenna_Marbles, блог, ютуб, telegram, youtube, артист, artist, people, люди, девушка, Jenna Marbles, telegram",
+    "nsfw": false
+},
+"247a6fa85e96fa9e9664232e49543caa": {
+    "key": "d4b3f8b00ef736f3f970b63702ce9e5564a1adfcb1aadd152385c68c8830305b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Anna Kostiv, JimCarrey, фильм, актер, люди, звезды, film, actor, people, stars, telegram, Jim Carrey, telegram",
+    "nsfw": false
+},
+"764b142bd2df409622f7e5137d613fdd": {
+    "key": "21de9a21cf761a60cd39cd40a2e001500b0359a1b1c00cdfe9ae3f36c95f27b0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Viktoria Moloko, JoanOfArc, telegram, средневековье, франция, революция, middle ages, france, revolution, Joan of Arc, telegram",
+    "nsfw": false
+},
+"696036ef846d0d3a14a9c381171d550a": {
+    "key": "3a2bd7c1033fd6e635624419f10bc4d20d31488c0199260006e87f745165a35c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Валерия Сикорская, JoeIsSadTurtle, животные, animals, конкурс2016, Sad Turtle Joe, telegram",
+    "nsfw": false
+},
+"7dbc0ddcdfb8da2c63a5e56865e084dd": {
+    "key": "08cad579436c36c4a6d24d172537eb063ba0aafe8bd0c59e536f92e9dfbf13e9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valya, JohnBlacksad, кот, черный кот, роман, графика, животные, cat, black cat, novel, graphics, animals, telegram, Blacksad, telegram",
+    "nsfw": false
+},
+"abfd604b4c9dd6ab2ff83773dc2bdc3b": {
+    "key": "ffe5c5883ba0efb05124429cd5eabf2007bd8a34f810363549d46104455184b0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Kakao_frodo, пёс, животные, собака, animals, dog, KAKAO Frodo, telegram",
+    "nsfw": false
+},
+"bbcdebf55a9d3ea2c21c5d94be0c092d": {
+    "key": "1040646865c1cd55ecd8fb42b3ec7b79fe7e89f385209cffbe81250dcf4e5127",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, KamikazeCat, кот, животные, animals, cats, Kamikaze Cat, telegram",
+    "nsfw": false
+},
+"3ae2c7a5b9f9ba0b9e726f130093d15c": {
+    "key": "2eb8b7910d6b05456291c1bc6cbde985c0219454deaa27e4afe4b49d7f37a864",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Karisha, люди, people, girl, девочка, девушка, игры, Russian Streaming Girl, telegram",
+    "nsfw": false
+},
+"ed23a58957e74994ff76b73e8fa8d8a2": {
+    "key": "aa65213c8a04441e637f880969183aeaeb72e28d5d33699b2d344956012961b5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Kashra, животные, собаки, animals, dogs, Kashra Stickers, telegram",
+    "nsfw": false
+},
+"d0a56c789e48d266a5f879a492e8ddaf": {
+    "key": "52ffe42f46941c8d45a1276f2d58a5e78311e2824f330ede57dcc0346cbad828",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "KateTheFlirtyCat, кот, животные, animals, cats, Kate the Flirty Cat @TgSticker, telegram",
+    "nsfw": false
+},
+"43b72e4b88a6361f468f098d21e4e534": {
+    "key": "351d731c951463d83c3e2b1167fe38a368198086d73fd05d0146ac18c9bfb459",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "KawaiiDeath, животные, animals, Kawaii Death, telegram",
+    "nsfw": false
+},
+"68a1c244c84188fc0415b1b11b4e9b13": {
+    "key": "73c337f4f561f2ce16590c068cf92c8a28ab2faf7db517e90e9bba7dbc35ca52",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mari Inari, KeanuReeves, telegram, actor, people, stars, звезды, люди, актер, Keanu Reeves, telegram",
+    "nsfw": false
+},
+"b36660eb8969560e8db0eb56c4da278f": {
+    "key": "267243d7e781b04fc5e9ab1e0eefa3ac6ec38da5003bf80ace46b3c17d0993cf",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "KermitHQ, Ма́ппет-Шо́у, The Muppet Show, tv, сериал, кукла, frog, лягушка, Kermit, telegram",
+    "nsfw": false
+},
+"af8dd7c4efcbff4030c820b794ac0eaa": {
+    "key": "59e7b29babcc0ae86cc6bf176edc58a81d46c3a00611985e5dba78ff2d5b998a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Viktoria Moloko, KermitTheDog, собака, животные, animals, dogs, telegram, Kermit The Dog, telegram",
+    "nsfw": false
+},
+"ea18041c6370983a197b20986bd1ff18": {
+    "key": "173e2a4f503658c1a8cc416d9e6ecfe009540a544240734c52d4fc1cbf7ef77a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "KrisKaspi, KidPorg, птица, животные, фильм, кино, звездные войны, bird, animals, film, movie, star wars, telegram team, Porg, telegram",
+    "nsfw": false
+},
+"1c7ed7d30e78a3c3bf256b5aacfcf944": {
+    "key": "cb89ad0ddd8c9c314e0b930445cab90a9fea477e3ea72e97bd77e963fd572dad",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valerii Matiukhin, KidsMTV, telegram team, сериал, мультик, юмор, series, cartoon, humor, Beavis and Butt-head, telegram",
+    "nsfw": false
+},
+"06cb525f5f5529db9f2b04a95a763f82": {
+    "key": "a1e3c962d4dfd2b59211ce556f9a3f7a4d551a9051cfaf1c7799d2a14b20c4d1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Дмитрий Кононенко, Kidsfromroom402, мультик, длядетей, forkids, The kids froom room 402, telegram",
+    "nsfw": false
+},
+"0debe2f2eaa818e3ad0bb605a2f29927": {
+    "key": "1e204bc9bc2c574ccb5057be424f1f95d81540343ac76c4cea8b0110c10a00d7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, KingLeo, животные, лев, lion, animals, King Leo, telegram",
+    "nsfw": false
+},
+"f4caaa447f84bfac36c1937c92aaaafd": {
+    "key": "4605f6ce5843aa98244ed835c269c83b75cf22284bca2b311bb4f1ef4223a7e2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Line, KirbyLineStickers, monster, монстр, pink, розовый, лайн, line, Kirby, telegram",
+    "nsfw": false
+},
+"2b59a68bd7d1af15e7974be14a2b53ba": {
+    "key": "4f933c7beee82a5f6d744bdee77d5e800ce15fd967492fdb8d23b37109827d90",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, KittenKitty_byAlexzhdanov, cat, animals, животные, кот, Котёнок Kitty @TuristasTV, telegram",
+    "nsfw": false
+},
+"71f473fd2eb94a734542b1b4e069881b": {
+    "key": "0de0657e8972d2e7f55712438cf146ee9b16668ee5f2cd305bbfc63f0a243b24",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "KittySweety, котики, кошки, кот, животные, надписи, фразы, inscription, cats, kitty, animals, Sweety Kitty, telegram",
+    "nsfw": false
+},
+"7b57ef463d508db23bc6ae58cc030984": {
+    "key": "1a44bc872f08f21a6e8d142e9016fb1a6219e5f3daf663bcac54d7a877077b78",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "KoalaChuck, животные, медведь, коала, koala, animals, bear, Koala Chuck, telegram",
+    "nsfw": false
+},
+"9e5e00979f71dd1ee980db1e695fec27": {
+    "key": "ce3455772ef23ebcb0b26fc02429db4822f3b33c7e12e1ce7755b92a8135749c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Nightgrowler, KojimaKaminandesu, япония, игры, japon, games, people, telegram, Hideo Kojima, telegram",
+    "nsfw": false
+},
+"897a344285218068ca5172e141ca0fd0": {
+    "key": "4f0581f46fe0335aa2084eef0364c456c4434b8c87652393ab29fcd382744afc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Kolobanga, колобки, смайлы, smiles, Колобанга, telegram",
+    "nsfw": false
+},
+"55ec8e1293dc1b8ec47cc1750217fe5a": {
+    "key": "0a6330d07aa1128b50e1ee6aa77db9787012362298a93d1f0ba4ab6101c9ff58",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "KookyCat, animals, кошки, животные, cats, Кooky Сat, telegram",
+    "nsfw": false
+},
+"339217a9ef7fc35d32630bbedf09877d": {
+    "key": "812c0466e1776273402c4da6191bc05c292321ac5d634310fca4658ca6eeef17",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "NTLENT, KoreanIdols, кей поп, корея, к-поп, музыка, music, telegram, OK K-Pop, telegram",
+    "nsfw": false
+},
+"cf343f4119c2baeca4890f9518d18069": {
+    "key": "a8995c2ca72564ca66364cae2c8adf85c4b0d4313b6364645b4aae326264fab4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Kotopesik, кот, собака, животные, animals, Котопёс, telegram",
+    "nsfw": false
+},
+"bd3b24ca69881c2034fda2d6eb42145b": {
+    "key": "f7e04b87e1b523c3b79829a5e678bc5b219aef4b0b1995cf1765b52f9098e145",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Nightgrowler, KratosAndBoi, telegram team, games, игры, God of War, telegram",
+    "nsfw": false
+},
+"5fc685d784fbc0c2f41c391c365cd8c4": {
+    "key": "c5e25d6c88af0a0a323290dd023954228c5a4a51ec4eea06da8ba73f4b74cc2f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Facebook, LEGOMinifigures, лего, фигурки, игрушки, lego, figures, toys, LEGO Minifigures, telegram",
+    "nsfw": false
+},
+"18acffb6e6dbfb25d243ee6420318721": {
+    "key": "3daf6b04deb469d1aa7d163b567c33fb443e35e1712b684ac4bcf80ef579a2d8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "L_u_v, сердце, любовь, отношения, поцелуй, день всех влюбленных, 14 февраля, шарики, Heart, love, relationship, kiss, the day of all lovers, February 14, balls, Love Love, telegram",
+    "nsfw": false
+},
+"c452310f0f18aa65d20386abc5045f83": {
+    "key": "46e0d0b1d2efc7ef102fc2f6e48a044f7c1ba16775ec9f0ad9335bede530aaf5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Snowy Jellyfish, LadyDeadpool, telegram, movie, comics, deadpool, women, женщина, фильм, комикс, марвел, дедпул, marvel, ванда уилсон, Lady Deadpool, telegram",
+    "nsfw": false
+},
+"84b16d245a8b6b7f508e82808114f188": {
+    "key": "b285c094f6d9b9dbd0e18e66d41fcb9860acc3e3ca5ba278d62d33c7f25eec34",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, LadyKrampus, новыйгод, праздник, рождество, фильм, ужасы, new year, holiday, christmas, film, horror, Lady Krampus, telegram",
+    "nsfw": false
+},
+"8fc5ededbcc68eb34c2b3af4b2aea78c": {
+    "key": "51a4d6f4522ee150481421c7c23f13e2600572e2c55eb6dbab752067837300e6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mary Virgin, LadyandTramp, telegram, мультик, собаки, животные, любовь, отношения, 14 февраля, романтика, день святого валентина, для детей, cartoon, dogs, animals, love, relationship, february 14, romance, valentine's day, forkids, Lady and the Tramp, telegram",
+    "nsfw": false
+},
+"8e2e0edefd56ebb3f73c10563bebeffd": {
+    "key": "3adc6ba813883c837d568184632862279ce3c55db35bfd77741852b742e066da",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Lama_stickers, лама, животные, Lama, telegram",
+    "nsfw": false
+},
+"caa4283e1a7be84454dae8c9c11c37f6": {
+    "key": "1e7b4589ed5a00f1784d41e195838653cd4648f642424b4a4648c3e911114e6c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeriya Sikorskaya, LaraCroftTombRaider, фильм, женщины, telegram team, film, women, Tomb Raider, telegram",
+    "nsfw": false
+},
+"d8af9737c1c71f32a87281e1bdb281e8": {
+    "key": "db1e657ae019f0e487b60916353f26ad48d95a7af4d75b93d678b78eae7ef051",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "LazyPandas, панда, panda, животные, animals, Lazy Panda, telegram",
+    "nsfw": false
+},
+"982b1d40d75a66be7f3425b57ffa4547": {
+    "key": "cc7d86f277d3752aa9cbd06bd14ef0f0cc3d235439cf6c73ed7139c89af49096",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "KrisKaspi, LazybonesJoe, животные, ленивец, animals, lazy, Lazybones, telegram",
+    "nsfw": false
+},
+"91802fa377be9feb12eb62769d1468b6": {
+    "key": "492302df476b2db4ed737105bf4dca5ffc20985fb06c6f5b6a187b3731ca845c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "LearnYourPlace, комиксы, английский, надписи, фразы, слова, Learn Your Place, telegram",
+    "nsfw": false
+},
+"78e1c148a3b685978663a7a2868bc870": {
+    "key": "0ee93ae39a3260b001222e551c588d5e7f143d037ed96217548d5c1c974e049a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "LegendsOfArtEng, art, живопись, картины, художники, paintings, painters, artist, LegendsOfArtEng, telegram",
+    "nsfw": false
+},
+"ad466a17aee82ab4edc57acaa0b2c95e": {
+    "key": "0de7dc580c29077319a41cb78f835c4fb3693eba528d33eabb029064f289d2a0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mary Virgin, LegoUnikitty, telegram, unicorn, cats, animals, животные, единорог, кот, Unikitty, telegram",
+    "nsfw": false
+},
+"ec338f20d5505575681e204452807b56": {
+    "key": "ad6fc9b8f2de1fd8afccb124a3c34a7d0193c315ff81c3a962de0e5ab62bbb7f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Дана Сидерос, Lepusalmons, животные, рыба, заяц, animals, fish, hare, rabbit, Lepusalmons, telegram",
+    "nsfw": false
+},
+"f5b278d101e475d10dd239057a85f4f7": {
+    "key": "db16a30ae81ac9611cc1cb6884500c933b562ed5349c242fcc5623f8c92375ab",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mari Inari, LeslieNielsen, актер, люди, actor, people, telegram, Leslie Nielsen, telegram",
+    "nsfw": false
+},
+"011f4d89981ec13348a84f0cc05cc8ab": {
+    "key": "3265b1f9e49f7b5f9fc1e6fe402aae73048455e2417e229bca29749284e6b2be",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Christopher DeLorenzo, LethargicBliss, ленивец, животные, надписи, фразы, animals, sloth, 😺, telegram",
+    "nsfw": false
+},
+"84e7553064d3f2577c36b3cf4c017f17": {
+    "key": "c9b01d7dc6c10bd7b1d1635e7dbd3efc04959f0e2544e8591e3047810f2cc055",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "LikeAMan, мужик, мужчина, люди, man, people, Like a Man, telegram",
+    "nsfw": false
+},
+"a01cfb699d8dacaa5d80daf48f66868d": {
+    "key": "d13c8d345b970bc78d04cf8722bf401b9a519ac28eb891748b1aafd5a5756325",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Daria, Likeabird, вird, птица, животные, люди, Like a bird, telegram",
+    "nsfw": false
+},
+"5e0e3c372b1259f60a7d6f1393818ef7": {
+    "key": "2bcbe20a4d05dbdf0c00a6d923a3a4d7768d39d8a94c2c04b671c43093834bcc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "LionelLeupold, животные, лев, lion, animals, Lionel, telegram",
+    "nsfw": false
+},
+"9c183661a02ade7763f07310931ef77c": {
+    "key": "28e47bd5ce9d9294812f2603b7a7b07424478e0b5aa0a2b2bb837d6ffbcb2930",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Natasha BikerBoots, Lisushka, лиса, животные, fox, animal, конкурс2016, Foxy, telegram",
+    "nsfw": false
+},
+"ef9f257a140b7fda5173b7742de90591": {
+    "key": "8aff45ba4ac3869f2188d4a9f6be7af108570899c152c5bc430337ec55c7e048",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "LittleDog_byAlexzhdanov, собаки, пес, щенок, dog, animals, Пёсик @TuristasTV, telegram",
+    "nsfw": false
+},
+"ef30d4e87edd8ae22adeb7cff12d55ba": {
+    "key": "09b22af8fc3d3a5732c80c00c649b828b8fba8a07078b4a1a1affa5615eec0f1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, LittleMouse, животные, мышь, Mouse, animals, Little Mouse, telegram",
+    "nsfw": false
+},
+"68fa47eb895874cbf3223be05e67ba5f": {
+    "key": "5f316d0e472c2bc6b611a1ccbaafcddfa3205c16d4cfa6fd3272b15e3f351286",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, LittleVampire, вампир, ужасы, монстр, monstr, horror, vampire, Nosferatu, telegram",
+    "nsfw": false
+},
+"1faee0b9054f880728b655b156734c8a": {
+    "key": "55ec4b53f78e8c3d26437dda4e5c78670abd50e26ff67e1492bf25f8af8bfe90",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Каролина Даргель, Little_Bear, медведь, животные, animals, bear, конкурс2016, Attila the Hon, telegram",
+    "nsfw": false
+},
+"500b6e017701f0c1989ff594409c0524": {
+    "key": "da39c2304d727bfc49e10ca24ee6dc8ded3d4123c0557b4cad26d880a91d686a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Little_Cute_Fox, лиса, животные, лис, fox, animals, Little Cute Fox, telegram",
+    "nsfw": false
+},
+"9bbdefcdbd6d881ce1d031cb62facd6b": {
+    "key": "b6c8e40d4882959135c76be680279ebbe7c4d9313b47caf44550a7d721ffc895",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "LoLlarge, игра, games, фейсбук, facebook, League of Legends, telegram",
+    "nsfw": false
+},
+"bf5a51ed368b1e02437ad514dbeaa8df": {
+    "key": "fca8fd478118eae173a57ed59620a59765bf31c956edeb8a27447fe1c5fec315",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mari Inari, LokiTheGod, скандинавия, древняя скандинавия, мифология, бог, scandinavia, ancient scandinavia, mythology, god, telegram, Loki, telegram",
+    "nsfw": false
+},
+"8799b58beb342992d2350c0fa17552ee": {
+    "key": "681344eb692ae4c7309581a75200877dbbfaca02de528d7faafdb5a627de496c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "LonelyPenguin, животные, птицы, пингвин, animals, birds, LonelyPenguin, telegram",
+    "nsfw": false
+},
+"4859a4240083097c3fe2217b16d8967e": {
+    "key": "720d3474fc0a13f13b1a9b7c4ddf45ac89ef5f9639d8668bdb5cf754f71181b3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "NTLENT, Lord_Voldemort, ужас, злодей, фильм, гарри поттер, хэллоуин, horror, villain, movie, harry potter, halloween, telegram, Lord Voldemort, telegram",
+    "nsfw": false
+},
+"e94b8ab63dc5602bb4e76d39f487eb1b": {
+    "key": "e812a9cccf3d3875c55b8272900facd5f993ca524485ae365dcf356962e39579",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "LosBlancos, футбол, football, спорт, sports, RealMadrid, telegram",
+    "nsfw": false
+},
+"359e48862e31000047f46e29e0c1d48a": {
+    "key": "29c77dedb63f3c50949215402fe0d5e304913266d556aaaf16fd20b3abb30c02",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Дмитрий Кононенко, LouieIsLife, мультик, длядетей, cartoon, Life with Louie, telegram",
+    "nsfw": false
+},
+"395b07850a18395fe09f5b9b6d741d8a": {
+    "key": "7951200905f71f040f8af02977f2c2890f0256ca5a7e62183aba8acf07af20b6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, LoveDove, птицы, животные, голубь, любовь, 14 февраля, день всех влюбленных, Birds, animals, dove, love, February 14, the day of all lovers, Love Dove, telegram",
+    "nsfw": false
+},
+"11fa5a9d372d30e98c9f2cf733c614aa": {
+    "key": "960ebb98386776faeb1bc5a84884d31a5ff10e66033ca3df837c1184ee01ced8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "LoveHarley, мотоциклы, люди, девушки, мото, moto, people, girls, отряд самоубийц, фильм, suicide squad, movies, Harley Quinn, telegram",
+    "nsfw": false
+},
+"12ec591a53251dcf11e489d095ce402b": {
+    "key": "581d44b25b365b9a2cb88dd6c07e1aa71d57ad9ed9b4f26a8e458cebf5fcd374",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Виктор Костенко, Love_Message, любовь, отношения, нежность, чувства, Love, relationships, tenderness, feelings, Love Stickers, telegram",
+    "nsfw": false
+},
+"57135b2b5c897f6e4295d7e70d40339c": {
+    "key": "b89ff3ce9462cfd89a354c4369ff967ea41b6f9c08bacbfea931910bb58d4c6c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, LovelyBanana, банан, фрукты, еда, тусовка, секс, любовь, деньсвятоговалентина, banana, fruit, food, sex, love, st. valentine's day, party, Lovely Banana, telegram",
+    "nsfw": false
+},
+"951cb1d498d7de0f20b6a73cda09b0a5": {
+    "key": "91bfdda810d4075d0b2e77552f31e080a5a85163b7203644a22391b374c05565",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Loxodontus, Homunculus Loxodontus, ждун, мемы, memes, любовь, отношения, день всех влюбленных, день святого валентина, 14 февраля, Love, relationships, the day of all lovers, the day of St. Valentine, February 14, Homunculus Loxodontus, telegram",
+    "nsfw": false
+},
+"bb64146f1550cbc3a790f8ceae4765f9": {
+    "key": "f3c1504d2653851ecd70eec3d78cc43b14d0d6b715c02ec27e291338e2172496",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "LoxodontusFriend, ждун, мемы, memes, @AppStorePlus ✓, telegram",
+    "nsfw": false
+},
+"9dfdfeb1d50cd38fee1b33228d2d3134": {
+    "key": "8c99e164ab03a64831382d88a34026f8df9551bcd8c16ea2da99c0bd387a3dfd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Luna_tik, космос, cosmos, планеты, Luna, telegram",
+    "nsfw": false
+},
+"24a9b7bb3b696190976aeda570038a0d": {
+    "key": "4e4774a85748616f21ebde4b4bef5dab04a48717e288e30f21b9791d9c205517",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Nightgrowler, MKTrilogy, игры, games, telegram, Mortal Kombat, telegram",
+    "nsfw": false
+},
+"cb879f8090fd07480ea897d5397cc388": {
+    "key": "5c9cf2eba0a2123fef9fbf26d50ff842c020f5d80d16b6cdb5d6dbccddb574cd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "MabelGravity, гравити фолз, Gravity Falls, Мэйбл, telegram",
+    "nsfw": false
+},
+"f953b4020c66c2005a1dd764ab2828a4": {
+    "key": "310b5e85bb586b96045fd13bec82a5cfce920efd1dc69257ab77f0464664062c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "NTLENT, MacronEmmanuel, франция, люди, политика, президент, france, people, politics, president, Emmanuel Macron, telegram",
+    "nsfw": false
+},
+"39cb90dca471ffe60877b902952c454a": {
+    "key": "cc8e7b5aa0e3cd7064b116b87a2ba1cf8400f1376dc35695113b975897c3d78c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Yulia iulaY, MafiaGirl, девушка, преступник, криминал, бандит, girl, criminal, bandit, telegram, Mafia Girl, telegram",
+    "nsfw": false
+},
+"750140e4d976fc5d180f1bcdedf78393": {
+    "key": "9e84e9ceb4c17e45ff52381ca2a3edd415b091e88fb7f559d3c79a60382d8ddd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Inarimari, Manool, животные, animals, милые, кот, cat, конкурс2016, Manool, telegram",
+    "nsfw": false
+},
+"72e2cf5823b43d9fa721b377e2141644": {
+    "key": "776ffb865796b0c419d8d3dd87e3168635e8aed02452e4da5ec5e43d5b12f773",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Мария Колесникова, ManoolGirl, животные, animals, Manooella, telegram",
+    "nsfw": false
+},
+"34d3a8d107a816cb6aa32b28a999255a": {
+    "key": "da54a5987e3fdc9df6830c8ac6a9cf2307f787d13aeca7fa7d47143bf5e128cb",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Marilyn_Monroe, пивица, актриса, кино, фильмы, Singer, actress, cinema, movies, Marilyn, telegram",
+    "nsfw": false
+},
+"4c1a456a82abe77b5a9425a07b1dfdfb": {
+    "key": "71dc3f53c188ce5a1e497d77da28d044e4030ad7c97d2d58b6569aa1cadd95ec",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "MarseyCat, животные, animals, cat, котенок, кошка, кот, котик, kitty, конкурс2016, Marsey the Cat, telegram",
+    "nsfw": false
+},
+"b7224e3cacd5f371ea513455547b983c": {
+    "key": "fdd4bfdf78bd69f6eeb590b8173338aa55036d91af932d58fedb9df30335cc58",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Vyacheslav_Rain, MartyTheBear, животные, медведь, bear, animals, конкурс2016, Marty Bearson, telegram",
+    "nsfw": false
+},
+"000f1a34c72d1393229abf17ddb35e19": {
+    "key": "c703e26c0923ca6214c3d3975a0c39c292acb039c94075b192fa88897ac8f44a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Masha Burdyugova, MaskByMashow, маска, фильм, актер, джим керри, jim, carrey, movie, actor, Mask, telegram",
+    "nsfw": false
+},
+"80dd389b53e03b876fa5367f9e83916c": {
+    "key": "3d02ced5a94ec7c4af5e3ab0531083819915212ef52469c7d066c06a193acbc1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Matrices, животные, собаки, dog, animals, Matrices, telegram",
+    "nsfw": false
+},
+"fac8e5f4810a2400ec2c9cb1ee283fef": {
+    "key": "813df1f97fbed7c4f5d69126c2770dda594b37c7929de438c0272a49fb49a24a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valerii Matiukhin, MeWantCookie, telegram, улица сезам, sesame street, мультик, cartoon, длядетей, Cookie Monster, telegram",
+    "nsfw": false
+},
+"1fddae3a57030084ac4874ac2040500d": {
+    "key": "efc44cf726d5821cfcfc28f68e7823de79a1890f0a1e18dc3ee4a2552b0fb5c8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Medieval_Cats, коты, животные, сердневековье, medieval, cats, animals, art, искусство, Medieval Cats, telegram",
+    "nsfw": false
+},
+"94dbca97064722145e33bf46f3c5ef50": {
+    "key": "9bd906eefecbeb6b9658f798c8015718fa3f5032cf27579a62f9c54ccbb300d0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "MeetThePugs, собака, животные, animals, dogs, Meet The Pugs ( @Perkovec ), telegram",
+    "nsfw": false
+},
+"119e18e2af940ef91f4b15216d155aab": {
+    "key": "ab891fbea86c36e34bd59444b4d48cfe83d978eb37e9b5672e424e02fbe7b130",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "BoggartOwl, MemeDoggie, собаки, животные, мемы, dog, animals, memes, Moar Dog Memes, telegram",
+    "nsfw": false
+},
+"c9adf67efaa4d2710cd421cbaf0ad01c": {
+    "key": "7da3453e10e0fb1c9d187001109995951ddeba24ead140e4cafde67bd297f652",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, MemePolice, полиция, надписи, фразы, мемы, Police, inscriptions, Meme Police, telegram",
+    "nsfw": false
+},
+"9d0302cd503a0bda992a98dbd8a177fc": {
+    "key": "db84c57bab6498fe9b2a017b7c4be2d30f0091aeeaabd6a9ea5138076a3db5ed",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Alyona Ostapenko, MemePussy, кот, животные, animals, cats, Pussy, telegram",
+    "nsfw": false
+},
+"a95f2f58812d1035172bea14ee1e3e04": {
+    "key": "eaa43bca1afc52ef04a9e87dbdc5911ee0d936a10cefe6b79ce0fcdcf3787a32",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Alexander Sorochinsky, MemeStickers, вконтакте, знаменитости, учёные, достоевский, менделеев, фрейд, дали, толстой, данте, гоголь, маяковский, шекспир, пушкин, эйнтштейн, ван гог, celebrities, scientists, dostoyevsky, pushkin, van gogh, poe, einstein, MEME Stickers by Sorochinskiy, telegram",
+    "nsfw": false
+},
+"f4d5faaeac43f116d8e2ec84297a7424": {
+    "key": "52c574c9b642e362b07557fccf5035902284646fbf132e4b9fff16574fdfa86c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Саша Sholudko, Meme_stickers, memes, мемы, Meme_pack, telegram",
+    "nsfw": false
+},
+"1b821f288598a8a6830e19bdc083c60e": {
+    "key": "4c41fde17e92f335201458eb3a4a2f5f570d9371aa288ec3a05aa69a40df2311",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Anna Kostiv, MenInBlack, фильм, movie, telegram, Men in Black, telegram",
+    "nsfw": false
+},
+"c8fbc727ad2efd408414215bd9bca248": {
+    "key": "bc6594440b58e4d8ceee1d85561f2e08a27fabf51afeb07b9894b740ddc32c28",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "MerkelPack, германия, политика, канцлер, женщина, Germany, chancellor, politics, angela, Merkel Pack, telegram",
+    "nsfw": false
+},
+"261a9e2cb5cfc10b6d1c89c383558fcf": {
+    "key": "e6d5758f65a6c0162cac60013b9ff67a351ec3fad755fae71ca96c9ae4c44a43",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Mesozoic, животные, динозавры, Dinosaurs, animals, Dinosaurs, telegram",
+    "nsfw": false
+},
+"58902d7b5b12066326c5c445e5743e6e": {
+    "key": "b582c6242db68b4a46ff64b3a3550425945f3976d82c64a491c3e0dd8f8c967f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Евгений Малышев, Metal, вконтакте, люди, персонажи, музыка, метал, music, metal, Metal, telegram",
+    "nsfw": false
+},
+"2525ac16a924be12919010dbdc51d028": {
+    "key": "ea349ae34fd39d8a4c1aa0634e0d9f1ac86942b0258e9d28399ae4d062619b45",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Metcast, погода, солнце, дождь, облака, тучи, времена года, снег, радуга, день, ночь, луна, звезды, утро, weather, seasons, precipitation, Metcast, telegram",
+    "nsfw": false
+},
+"b171e6b427683586179167482279e7b1": {
+    "key": "91ea40ed43229eaa5f0be1599cda842a2a72324ca4e56e5116e8f3395e6ba90c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, MiaCatlady, люди, животные, кошки, cats, animals, peoples, Mia Catlady, telegram",
+    "nsfw": false
+},
+"0c274af417286e834d6e0400f1ca922e": {
+    "key": "c99321df927c262384fb67a1026256c1f6fc5b388037ad76d2c17b24fbe7838d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mickymouse, мики маус, мини маус, дисней, мультики, для детей, животные, animals, cartoon, Mickey Mouse, Minnie Mouse, disney, Sepehr&Roya, telegram",
+    "nsfw": false
+},
+"ddee3402da306eed4c41ded7c91f0e67": {
+    "key": "e2ad8331654f5e8654f20372628fb0d8e3256285d646a0ec96ffa02519d10892",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Krasivon Art, MicrosoftBillGates, бизнес, деньги, америка, люди, microsoft, business, money, america, people, telegram team, Bill Gates, telegram",
+    "nsfw": false
+},
+"bf0b3ac9e2705a3503c3107cdab20239": {
+    "key": "e2a2fcd7db12ce5aaa9e8fa1f558a20cde1144f34a2694bf693b9f9101ecb7cf",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, MillionaireFox, лис, животные, деньги, успех, богатство, foxes, animals, money, success, wealth, Millionaire Fox, telegram",
+    "nsfw": false
+},
+"a3eaa4b519064f9014702a21bc056cc8": {
+    "key": "4fc3e7f342d61d374b7708755dc1334cac6226d23997760c2576cb8cd26e2de1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "veronika.redfox, MimimiPink, зайка, заяц, животные, милый, 14 февраля, сердце, любовь, день святого валентина, bunny, rabbit, animals, cute, february 14, heart, love, valentine's day, Mimimi @veronika.redfox, telegram",
+    "nsfw": false
+},
+"0297182908bd57510915f6838f45eb7f": {
+    "key": "e50a120272ec693c6ee7ef32b49853c466f22eab137dfbce684bc59669e7cf86",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "MishkatheBear, мишка, медведь, животные, bear, animals, Mishka, telegram",
+    "nsfw": false
+},
+"16e65faaa69972398d28e2ec35048c70": {
+    "key": "ed40f56802fbdd0c1d12a4a7ca6cdc38a00d9078cffe0ff5c708fc7c1489e3ab",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, MissAlena, модель, люди, девушка, блондинка, телеграм, model, people, girl, blonde, telegram, Miss Alena ❤️, telegram",
+    "nsfw": false
+},
+"bb9e31dc292b3fdf7c6eeec14774a173": {
+    "key": "477dec7cf0d9bd4a77517f89ecdb584779824cf369c607ba20a7b80580a5bdee",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, MissDevil, люди, женщины, дьявол, черт, devil, people, зло, evil, Miss Devil, telegram",
+    "nsfw": false
+},
+"92fb133fc1b9cbeb55f99d8508538b04": {
+    "key": "1c58ea009ec7d858af32e1987a5a3699f4fe3f74cac7daee31dd099107c74a4c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, MissHepburn, Одри Хепбёрн, Audrey Hepburn, актер, actor, Miss Hepburn, telegram",
+    "nsfw": false
+},
+"156ddde9276578e0ffe952b144435418": {
+    "key": "e6659bf6271e136aef254eeafadfacc764f8002f21f7804c39db4e05ad2f0d44",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Tamara Gerasun, MistressoftheDark, хэллоуин, тыква, ведьма, ужас, женщины, брюнетки, halloween, pumpkin, witch, horror, women, brunettes, telegram, Ms. Elvira, telegram",
+    "nsfw": false
+},
+"17097250a76df942f85a1bedb1329408": {
+    "key": "9b773466ceb530d5c728165e8a129cd27d783a06beb60c8983c218acfe5dda62",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Boggart Owl, MoarKittyMeme, telegram team, коты, мемы, животные, cats, memes, animals, Meme Cats, telegram",
+    "nsfw": false
+},
+"cde6575d8ebbf2b5db7e6ac2f4bd6fdc": {
+    "key": "0dedcc758af1624a77ec0cea493f052d69b189a2a9f9cb5f7d48ca94a8346c3b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, ModernBuddha, будда, нирвана, nirvana, religion, религия, Modern Buddha, telegram",
+    "nsfw": false
+},
+"5ceaa70bdc960eee733093f22dd6b922": {
+    "key": "619ce0173556e7bf5c1d56ca187e19b53fe0c57e9420ca00ab8186e9678e98b4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, ModernGeisha, япония, люди, гейша, культура, Japan, Geisha, Modern Geisha, telegram",
+    "nsfw": false
+},
+"826abef20961125ebb735ca38b23e88c": {
+    "key": "30aaa02827413f569c83b41ff8af7e91bb06245e88d9166519d9c3ac7c3cd2a9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, MomokoStar, момоко цугунага, япония, люди, музыка, певица, japan, people, music, singer, Momoko, telegram",
+    "nsfw": false
+},
+"7db09915c3e279125a6520ce615fde60": {
+    "key": "2bafa1dfba41018f52c0e54ea92709229c72e10110c6a60869528456699c26af",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "MonaLisaParody, картина, арт, искусство, юмор, mona_lisa, telegram",
+    "nsfw": false
+},
+"4b34bba225212823dfb82dbe72dbecb5": {
+    "key": "c6e9bbee92dc42867a4e6d7841b70b0482a0e5231577c2a367481c374ed23326",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Moomin Characters ™, MoominLittleMy, девочка, вредина, люди, people, girls, Little My, telegram",
+    "nsfw": false
+},
+"d7e73a7f608e30fc0d66546537ba97cd": {
+    "key": "de9c9cafa4e79f1e1ec9b0ab45f5a171863e2a11b79e68635388db9582ee8034",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "MoominNord, mumintroll, туве янссон, Moomin's, telegram",
+    "nsfw": false
+},
+"1abb9d9c2b840fba2752286596952d30": {
+    "key": "13d6bba70e1444c525a70b15964b44053ddb2c68f7473ba542102bca3e5ebc84",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mooncake_FS, космос, инопланетяне, монстр, space, aliens, monster, Mooncake, telegram",
+    "nsfw": false
+},
+"b07a9f4973c1bdcb15134052d6d648cc": {
+    "key": "6263b145d5d7231f0eb46b105703f48ffd262a53fb49c8401785110ff25ee4da",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "NTLENT, MrBat, telegram team, животные, мышь, летучая мышь, animals, mouse, bat, Mr. Bat, telegram",
+    "nsfw": false
+},
+"866a72d64f214d5f6823a14314679ef0": {
+    "key": "9b4cd6ff458660fa3266ac111000ccd67c63838f2e9071da5773c91d5d960d6b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ulyana Tkachenko, MrBeanShow, telegram, people, humor, люди, movie, фильм, актер, Mr. Bean, telegram",
+    "nsfw": false
+},
+"1237f5b34f8e2852954eb1a9e8e1f166": {
+    "key": "6f08763eb538b459c86a9c38c1ba0f3fdb32e612a6fd456034b8ba829692cdda",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mariia Furdei, MrBearBoo, рисунок, медведь, животные, bear, animals, авторские, Mr.Bear, telegram",
+    "nsfw": false
+},
+"c216b04f036c19f0b5dea3ea07bdf301": {
+    "key": "dd8dddebfae54a6d09ceaa88e95ff78405f91c2ebf824e18387412199d40df21",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "TOXANDREEV, MrBlanket, одеяло, спать, sleep, Blanket, Mr. Blanket, telegram",
+    "nsfw": false
+},
+"ebbbbafdd952b51b721a64e21a47a063": {
+    "key": "5cad1913aad7a3c016da0284eb576e3331b2e452add2261091c71f83e4a6e4b6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mari Inari, MrCage, actor, people, telegram, movie, люли, актер, звезды, stars, Nicolas Cage, telegram",
+    "nsfw": false
+},
+"c56516313ec4a9597c7b176733d98913": {
+    "key": "17c3d84fa708fa5ab23437c5a53c1a6eb509fd9a2152cad95123e3d6945e1ff5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, MrCapybara, животные, копибара, грызуны, animals, copybara, Mr. Capybara, telegram",
+    "nsfw": false
+},
+"d4f39c7c4b0db5f64c5a7a31f318879d": {
+    "key": "de87060fc01e0d939aba4503337aa174d0a9016e19a199219c47644baf664dca",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "MrFat, кот, животные, жир, толстый кот, рыжий кот, cat, animals, fat, fat cat, ginger cat, Mr.Fat, telegram",
+    "nsfw": false
+},
+"e141694556df5974fcebab09a0130324": {
+    "key": "851a4308d86018fc58a74daf51d3dd4855b503b98be2206e0ab10080f560be93",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Sun Shine, MrGull, голубь, птицы, животные, pigeon, birds, animals, telegram team, Mr. Gull, telegram",
+    "nsfw": false
+},
+"f7d5376aba64ef4fb34069cdadfa14b0": {
+    "key": "4522b83706ba7e71b28e9a54f525196531aa10aef01d556d40e987fb956b0a86",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "AnzhelikaJoy, MrHamster, hamster, хомяк, животные, animals, telegram, Mr. Hamster, telegram",
+    "nsfw": false
+},
+"1365fac404af68c79ee339f835d007be": {
+    "key": "a49f3494ca4d29b49464a1c6358244c7d799ec65dbf12936e55884c87cb76344",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, MrNut, еда, орехи, food, nuts, Мистер ОРЕХ @TuristasTV, telegram",
+    "nsfw": false
+},
+"d1ad04e0a0fd4505f65f349b156f7c24": {
+    "key": "87f364726b0db882afb28ac1ece01586e500a169d2ea1b0d5e303260a94fc1c9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Snowy Jellyfish, MrOlaf, telegram, новый год, рождество, праздник, зима, снеговик, снег, мультик, холодное сердце, год, рождество    new year, christmas, holiday, winter, snowman, snow, cartoon, cold heart, Olaf, telegram",
+    "nsfw": false
+},
+"d7d2d1d9cd9916e4939ad55dfe3f026c": {
+    "key": "99fcfced8fb4f6dc28d7b619882bfaf96f94c0b80f5a6d9f541de3dc6d1544cf",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, MrPennywise, оно, фильм, клоун, ужас, стикен кинг, хеллоуин, it, movie, clown, horror, steven king, halloween, Pennywise, telegram",
+    "nsfw": false
+},
+"06e67d1ab68722476a95e693d0fe3ecd": {
+    "key": "daee53c1153de02df19fbffd9e82f7701660b1e9b917f41e96229dd21e7f82da",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Sergey, MrPonch, повар, еда, люди, кулинар, cook, food, people, culinary, telegram team, Mr. Ponch, telegram",
+    "nsfw": false
+},
+"e659f64db32801b102c4ae098f583c93": {
+    "key": "19ef655e1025d8990c13403499c261dc67e164a4953ba3efa93576fa81ca5ba5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "anna shaggy, MrRaccoon, telegram, animals, racoon, енот, животные, Mr. Raccoon, telegram",
+    "nsfw": false
+},
+"044443dc938585101ad7b126381325d2": {
+    "key": "ef5e925bc3bb5ebca119c34cfc09a22be0c304ac0c3e1ae55667aa644ff7dc17",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "BoggartOwl, MrSalem, telegram, cat, animals, hellowin, sabrina, the teenage witch, series, кот, животные, сериал, хеллоуин, сабрина маленькая ведьма, Salem, telegram",
+    "nsfw": false
+},
+"8f64b25e7ac7a247b41263dc473f37ab": {
+    "key": "320b6f31e0f91e6e9d61ea699699da15cf70d43590a582af6711f332f42913f1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, MrShark, акула, рыба, животные, fish, shark, animals, It's a Shark!, telegram",
+    "nsfw": false
+},
+"6fc94f143c21a88ce345e888eaa4d756": {
+    "key": "b65537f0d77257d570812bbfaf7dba4c38a8958388d33aaec9b3c62e8fb8380d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Vyacheslav Reyn, MrSnoopDogg, telegram, музыка, люди, music, Snoop Dogg, telegram",
+    "nsfw": false
+},
+"81a345ce57442dac1c1f11dd2ca0d00b": {
+    "key": "258266e58df55de4fde3caffd808db931b8d6e81caf7764ec52f6d6c0a5ddcc7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Stasik, MrWolverine, marvel, comics, марвел, комиксы, telegramteam, Wolverine, telegram",
+    "nsfw": false
+},
+"b55ac00b75f46b48e02eec3bea932b9a": {
+    "key": "daeb9b474d8918ea6eb2742d971863006b65e6d0a6ba19b878e7f818457162c0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, MrZoid, сперматазоид, биология, оплодотворение, секс, spermatozoid, biology, fertilization, sex, Mr. Zoid, telegram",
+    "nsfw": false
+},
+"9ea4b8aa62b91c886159ad1042f3b82c": {
+    "key": "b660e36fce7afa5eb0e7cf5759fcd9ec99640a2c00e4d7baf3df1323376f3e64",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valya, MsAriana, люди, девушка, музыка, певица, song, songer, people, girls, telegram, шатенка, русая, Ariana Grande, telegram",
+    "nsfw": false
+},
+"894373e491ef14dd14097f97e65a9064": {
+    "key": "6dd5694d7fd7b2055e27e98c266df913f85787a0a641a59cdf90ac382f73da5e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Tamara Gerasun, MsLadyGaga, telegram team, музыка, певица, music, song, singer, песни, Lady Gaga, telegram",
+    "nsfw": false
+},
+"408f3abc126925238143cd23c0825f3f": {
+    "key": "fc62abba2a3b91d09ca590f199f50868e7ff1a7e49713c74dcee807b8ef57cb2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, MsPaws, аниме, люди, девочка, girls, anime, people, Ms Paws, telegram",
+    "nsfw": false
+},
+"0475e16eae947a9a43e269178f68036e": {
+    "key": "3192137edf303b21619821e4cd20cd62ce08e5038c24bd668a8e91677f407fbf",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Мари Zeligen, MuchCryptoBotDoge, животные, деньги, криптовалюта, биткоин, money, animals, dogs, crypto, bitcoin, @MuchCryptoBot Doge, telegram",
+    "nsfw": false
+},
+"4f48873b100b1038940268731c2c3913": {
+    "key": "60315fa65e9ede2546713a63a391899e82f1362ef7350afe92879b503ed8f964",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Svetlana Imasheva, Muffinson, еда, выпечка, кекс, маффин, cook, food, cake, Muffinson, telegram",
+    "nsfw": false
+},
+"23c08f17299e965d29d8067c70f8af13": {
+    "key": "06ef6e5a03c94147eaa38fab6e28727e070fed4a86435be6728ce0ff8839f944",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, MuriSecretary, работа, офис, кошка, женщина, будни, секретарь, профессия, Work, office, cat, woman, everyday, secretary, profession, Muri The Secretary, telegram",
+    "nsfw": false
+},
+"2142a8323f78be1a3cf8af97f331e4e6": {
+    "key": "cfe69cfb00b135e9b8876b66e0030310bf39ff4e7c508be74aa9e972312a49b5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "MuzzCorgi, animals, dogs, животные, собаки, Corgi by Muzz, telegram",
+    "nsfw": false
+},
+"d2fdcb7f28d22549c7ffc32bb21231f4": {
+    "key": "18b805a6140790430c0c8fbba80d03fea751575621c605187e86d2670f2e4c9f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "MuzzFox, animals, животные, Fox by Muzz, telegram",
+    "nsfw": false
+},
+"7dfe1734dc85be3fe2e9db6325be6e7c": {
+    "key": "60ac0bb9c29f7e6c06d8b8efee476357a23c8984a205d0b2725b7e9e4378edc9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "MyCafe, кот, кошка, котенок, животные, кофе, cats, animals, My Cafe, telegram",
+    "nsfw": false
+},
+"9bb171ab68d257d506d445634540eff7": {
+    "key": "f57bf0c126581b86884e55547a776792da8b3185a579c09f4c3d56092b37d432",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "maxhasky, MyNiffler, fantasticbeasts, niffler, cute, animals, фантастические твари, нюхлер, милость, животные, telegram, Niffler, telegram",
+    "nsfw": false
+},
+"49e73720380ecda9d6e29d449b8a1544": {
+    "key": "5e78d83cef68b1033109d7995f4cccf133e0d8da4b4e1d4776f665d91d6046e3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Maxhasky, MyNightFury, как приручить дракона, how to train your dragon, мультик, cartoon, telegram, Toothless, telegram",
+    "nsfw": false
+},
+"6907684236e8c112eafd028d374194e4": {
+    "key": "3c6ea98a2c617f380b2d7467da8de2918f3dc03dcec23364d86ba8176cdc98fb",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Krasivon Art, NapoleonEtJosephine, telegram, отношения, 14 февраля, день святого валентина, любовь, наполеон, история, франция, relationship, february 14, valentine's day, love, napoleon, history, france, Napoléon et Joséphine, telegram",
+    "nsfw": false
+},
+"715dfd41bccb1ba63cf6d526e93af13d": {
+    "key": "fb854af47d14604fcedfef9914fbe848697d697cb312469bd786bbfd7df033aa",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Настя Дружининская, Nastin_monster, monster, монстрик, Monsters, telegram",
+    "nsfw": false
+},
+"026f8b017f5f623f4f614230818e7f8d": {
+    "key": "01aa2b38e81ff93e74e86a583631932cd1dc38233259abae8f402f19a86642ad",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "NekoAtsumeOfficialStickers, неко, атсуме, официальные, япония, игра, games, officical, Neko Atsume, telegram",
+    "nsfw": false
+},
+"ca66c458f959478b2ef022f08ae19343": {
+    "key": "025de1a16d890fa1a73f698b05ddf88d279663a6a743ce974de7d34c223d24df",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, NeonAndSigns_byAlexzhdanov, улица, арт, знаки, стоп, сигналы, надписи, слэнг, НЕОН    и уличные ЗНАКИ @TuristasTV, telegram",
+    "nsfw": false
+},
+"15b469e51bb6e6088d5957fc984ea690": {
+    "key": "00b0a98979c8fe546c861bd2e9da416ea75016dce3bd94bcb40306645c087d24",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Владимир Хаецкий, NeonDemon, неон, кот, животные, сфинкс, animals, neon, cats, telegram, The Neon Demon, telegram",
+    "nsfw": false
+},
+"4b3e3d2a13ab2d006d53197efec7ab6d": {
+    "key": "1d60e6ae3f31b98b4cc0d70eec6ec6143537b329aa40eadbac2789b564314b08",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Анита Вацек, Neonboy, арт, неон, art, boy, мальчик, NEONBOY, telegram",
+    "nsfw": false
+},
+"2f684ed96928b8cb5e4ce079d38062ca": {
+    "key": "9b82628c5542684d3da99b390c07a93b10db9f78438ece3ea4c409574132d45a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Баранов, Nexy_Fox, лиса, животные, fox, animals, Nexy, telegram",
+    "nsfw": false
+},
+"f79bc0791a3c9b0aff91508d4903fe6d": {
+    "key": "c547081157d2adf4e85d844cbf85d82d84d7e929b332174d453e0a4d012b067e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "NiceGiraffico, животные, жираф, animals, giraffe, NiceGiraffico, telegram",
+    "nsfw": false
+},
+"91faae0fd14f93fe4fd9704197d4aa21": {
+    "key": "ff21d1dbd63d6f2a389420880db3660a97d3f20bf1bcec6b9f4c7c719bca5a53",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "NicoTheSeal, животные, animals, Seal, тюлень, Nick O'Sealy, telegram",
+    "nsfw": false
+},
+"80302237bec868b8ba1deef1f92e7a71": {
+    "key": "512cd80729c479b8bdeb92f02ff570b36d8249c20d096d0ac9b659c951e111d1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mari Inari, Noirpack, кино, фильм, movie, telegram, Noir, telegram",
+    "nsfw": false
+},
+"38ce47063b18f2cd7a5fb5f5c9385b2d": {
+    "key": "577ff94e2eb34f2f796f903552b21c54e1dcbd16e4ad250d7f278d184699a28e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, NorthKoreaKim, ким чен ын, корея, политика, Kim chen yen, korea, politics, 김정은, telegram",
+    "nsfw": false
+},
+"6c7241a66ba3ecacae9234c943bcd4c7": {
+    "key": "fdd13b02d4b2ff99a615a10dfb964122ac6bf2e5548e01a9ff8e202802b2d22b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Kristina Weber, NotHamster, animals, humster, cute, Not a humster, telegram",
+    "nsfw": false
+},
+"28a59af38b0df7740534a0d9b97085a7": {
+    "key": "3f84630141af164dd0f9e1e924921d0fc6e60a05b0838fc81ca463d066d68f07",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Oakley, животные, птицы, сова, филин, own, birds, animals, Oakley / By OsmerOmar, telegram",
+    "nsfw": false
+},
+"1335e5002ef3bf67225ddcfc02ac3ccf": {
+    "key": "743f7c9e713d912e953496279cefd2843843b91a3e1043e9d081232ce192a21e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, OctoGirl, осьминог, девочка, люди, girl, people, octopus, Nurse Octopia, telegram",
+    "nsfw": false
+},
+"c487335ca6b09dcade28c2b23aed43de": {
+    "key": "c5c8f57c5123b354b6cd66156c97ad9dcd56771b57b4b380d2b6cdd64bc302c2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, OctoPrincess, люди, животные, octopus, осьминог, people, Lady Octo, telegram",
+    "nsfw": false
+},
+"5b01fee2568b53452b734188e887d8d1": {
+    "key": "503b891ee0e3b06a39c180f4ab8440f2cd426d7ab60be84c9523fa843410d1dd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Stasik Busy, OfficeWerewolf, волк, ужас, оборотень, хеллоуин, terror, horror, werewolf, wolf, helloween, telegram, Werewolf, telegram",
+    "nsfw": false
+},
+"b9e0f8a2df3df5282134c454be1e771a": {
+    "key": "843d7061193076cdaef15ae6034aa6e016b8ca346387ab2e9e01af59171ac7ca",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ohthislife, жизнь, быт, работа, еда, утро, life, work, food, morning, Это жизнь (lingvistov), telegram",
+    "nsfw": false
+},
+"33886c8c128f10181793fbc70faef2ca": {
+    "key": "88abd7e081713f6566efbf02065d66bc57b5113d31557682ee5dea4c97424c7f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Tamara Gerasun, OldSchoolTattooGirl, тату, девушки, искусство, люди, tattoos, girls, art, people, telegram team, Tattoo Girl, telegram",
+    "nsfw": false
+},
+"d642cd9f06a3388c3961f7965a36fa85": {
+    "key": "f6945d60612ae8b64b21d507996f4c0eac54e45848c01453c25c6bb1356f8568",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Onionhead, смайлы, эмоции, smiles, Onion, telegram",
+    "nsfw": false
+},
+"a383641f4449f1b2c3733815ca28c9e5": {
+    "key": "ccd411ec75c725477476a3f49d559c93ed668febb2f0c816a43eda2dbc258b26",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "anna shaggy, OppyTheRover, марс, марсоход, космос, rover, space, telegram, Oppy, telegram",
+    "nsfw": false
+},
+"a5ca64b0beb81a91b266bdc3a5b06580": {
+    "key": "3e003e84660e2e985bf21895b7e8fb884f8ddf96178d3f617d912bb9ca4aa817",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, OrangeSunshine, животные, кошачьи, оцелот, гепард, cheetah, ocelot, cat, Orange Sunshine, telegram",
+    "nsfw": false
+},
+"2e771da0cad0a4934a416c919332b0a3": {
+    "key": "8c4336d6ee441df1ee5feaa05c15a441ac0a0560663bb1cf2abbc7eba475d358",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "David Towne, OrcFrank, орк, монстр, orc, Orc Frank, telegram",
+    "nsfw": false
+},
+"9844fb71ae7c233165788369013c9c95": {
+    "key": "bce507b33428d1d7cd41a7d5e3c46ff8537857f0a200ae4c78dfd07aec393df9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Настя Тёплая, Orca88, orca, косатка, кит, orca88, казино, Orca88 the Pirate!, telegram",
+    "nsfw": false
+},
+"94922ce4b0494765b13eb31d171df581": {
+    "key": "9b75900e3bbe7fbc7d50ed0a573a9b1c8698c803388c3e00893dfba93cad86cc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, OrientalWisdom, мудрость, конфуций, Wisdom, Oriental Wisdom, telegram",
+    "nsfw": false
+},
+"19929b26e5c4c9903bb2f49ca085c790": {
+    "key": "a3771d57ddf479231ad877ea256ac2bb6781dbafefb2ee992befd796a320d58b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "OttoMan, выдра, животные, море, Otter, animals, sea, Otter Mr. Otto, telegram",
+    "nsfw": false
+},
+"5ba1f1965f4800779939939ac104a735": {
+    "key": "c387f9ee8ac2e961c7de1868a9cf714a3b3bd96963725b30779bfc3d059c10fb",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "OuterGods, Говард Лавкрафт, монстры, боги, древность, ужас, писатель, книги, Howard Lovecraft, monsters, gods, antiquity, horror, writer, books, GreatOldOnes, telegram",
+    "nsfw": false
+},
+"3f0207070aaa4de2d168c10c6b9d1c7f": {
+    "key": "ac766926ae4b2aa2d055ea5597899c9197f81e84bd334000a13b390cbd6a0092",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Каролина Даргель, Owlet_Savva, животные, animals, сова, owl, bird, Savva Owler, telegram",
+    "nsfw": false
+},
+"de29e7933051cfcb9c5ba1936d2a3847": {
+    "key": "2e66872f7d76f98db9af5160f6d33e38e1ba512ec70c1459d7a50f1bffc3148e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "FawLog, PEPEtop, мемы, memes, пепе, лягушка, лягушонок, frog, PEPE Top, telegram",
+    "nsfw": false
+},
+"96b90afa232ea79bbfd6ab4c109be4cc": {
+    "key": "fa79763c4fa665706d447aac7b1b7de8001a0d85d610800349611444b41b0a10",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Palata6Kris, Devil, girl, miss, девочка, девушка, эротика, дьявол, злость, Palata6Kris, telegram",
+    "nsfw": false
+},
+"59ef0e8c8286658589fb2c098a887431": {
+    "key": "177354ff1d20d90b68f62316d994ad5e2d0f962581696eae9809179d3361ed87",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, PandaChan, животные, панда, panda, animals, Panda Chan, telegram",
+    "nsfw": false
+},
+"2a23c4b7a31a2b5bbd709454d6e4fd79": {
+    "key": "a0efcb1dc9e9c2613b89c75e82197abbc451a7cf0eeb7e6e1967bfb475d0dc79",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "PandaTeam, животные, animals, PandaS, telegram",
+    "nsfw": false
+},
+"b1fb19f90fc509bdb4d8d82e5dbb8375": {
+    "key": "f57e6d57ced01ec176f8e5ce244c67cf6baf0f32a648788da8b470d286da370a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Лиза Фомушкина, Panda_LizF, панда, животные, animals, panda, Panda LizF, telegram",
+    "nsfw": false
+},
+"0142fde8a3df87c46a41c11bd9579afe": {
+    "key": "1b172e385b989724b2a168b6763f22f0a74ffd43945d1424599dfbab2d5b4880",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Darya Ogneva, PaperAirplane, telegram team, самолетик, бумага, свобода, телеграм, ркн, блокировка, telegram, airplane, paper, freedom, Paper Airplane, telegram",
+    "nsfw": false
+},
+"88cba66a43b7bbb534d38beef31aacb9": {
+    "key": "7d6025193e666fcab64dfd4f794bd63b4c386504e8bded28d74f411f31916c66",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, PartyDog, пес, животные, вечеринка, алкоголь, любовь, бабы, бабник, мужчина, бухло, dog, animals, party, alcohol, love, women, womanizer, man, тусовка, Party Dog, telegram",
+    "nsfw": false
+},
+"33050510d2d50be5d1a86283c8ffb597": {
+    "key": "c18fd6424df14069870dc63398bc8b2f9f0f98acc19c99c3a8ce02b0ab7e158a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, PastelGirl, люди, девочка, девушка, peple, girl, Pink Power, telegram",
+    "nsfw": false
+},
+"00015ff87dbcf77ab7b18fcba318a483": {
+    "key": "218a4707a65cf7aaf27a6e0d2818ca476e5b1f3f4a1099da9546e724cf545a6e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Pastilaopt, Pastilaopt, единорог, unicorn, pastilaopt.ru, telegram",
+    "nsfw": false
+},
+"e5fffc2834d2c54dd7decb87534a7440": {
+    "key": "5deaa8e6acad031387cab804c74cf8dccf6419d58f942c06837e3b3379c84dfa",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Dima E, PatrickBob, мультик, длядетей, патрик, губка, forkids, cartoon, patrik, telegram team, SquarePants, telegram",
+    "nsfw": false
+},
+"6023f7540bd1385c4c648b0b0ea5b353": {
+    "key": "a0ae7937713afe64985e0f53eaacf7703a8e5fb9019faf48a44556801a58393d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "PePe_Trump, мемы, америка, президент, лягушка, пепе, Memes, america, president, frog, pepe, PePe Trump @kyprijan, telegram",
+    "nsfw": false
+},
+"3c5677f7d2f72ed5e25ac6f918612f87": {
+    "key": "8e8a879ebf192af4cf0ef02ec328a78e5876701fad33a476f7230131ec373747",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Pelmesh, кот, котенок, животные, cats, animals, Пельмеш, telegram",
+    "nsfw": false
+},
+"73f7cb297dddf877b760f2bb978e5c92": {
+    "key": "e782bd67d655418f00df31774c79b887d75e8ab7d1a2477ca0fa32e8d82e8a51",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Pencha, toys, bears, cute, love, любовь, медвежата, игрушки, පැන්චා, telegram",
+    "nsfw": false
+},
+"d433280f906c5fd74baa4d975d74fa30": {
+    "key": "e79cfdfafd9c6cb19f0dee081ec3b826b82fbad6af3edb63cd796c1b728428be",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ilja Shapovalov, PenelopeTheElf, telegram, новый год, рождество, праздник, зима, девушка, эльф, new year, christmas, holiday, winter, girl, elf, Penelope the Elf, telegram",
+    "nsfw": false
+},
+"fa043f89a6d401a6166459997e7271ad": {
+    "key": "fc698fb642e7e4d261582974ca315e3d76a6b44f609d1e694d4046a07815700d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "AnzhelikaJoy, PenguinKevin, пингвин, животные, telegram, animals, penguin, Penguin Kevin, telegram",
+    "nsfw": false
+},
+"b7266ef42bd898582b7f42b299ab77d5": {
+    "key": "5c425973a47880280dd9ef8b1cc2efb52f2c5d9951cefe32b1591461a0fc1769",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Yana_aquarelle, PenguinPini, животные, пингвин, зима, winter, animals, penguin, Пингвин_Пини, telegram",
+    "nsfw": false
+},
+"3f1e2e62dceaa52e7f35740a87356cdb": {
+    "key": "99f484ab0574615eb390a06ea151cfe12c6a7a875b8b8be19178aad1767aed0f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "PeopleSuckStickers, phrases, фразы, слова, арт, мизантроп, People Suck, telegram",
+    "nsfw": false
+},
+"01d29faf7921faebb2f385d74da0f15d": {
+    "key": "5d2ee2ef7f860e6248b4546dcaf3ddb4610f62b9b6c88af2cf7e8e7077b37dfc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, PepperKtusha, люди, пират, девочка, girl, pirate, people, Pepper Ktusha, telegram",
+    "nsfw": false
+},
+"cd5cd54328a891ba1c0906a475ca9e66": {
+    "key": "e91e8f7a59b3f8f5d811a8ea7133ffeade1772c74bea13ece02f84c95866bcc5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Elena Savchenko, PersikStroke, вконтакте, кот, персик, животные, animals, cat, Персик, telegram",
+    "nsfw": false
+},
+"c74fb7c6d7a9ff1a0b260fbe1b6e3a18": {
+    "key": "aac4d3830012c642c08727a299ab014fbca730a40d3d92a80ad43a94a2de82fb",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "PeteThePig, животные, свинья, хрюша, pig, animals, Pete The Pig, telegram",
+    "nsfw": false
+},
+"de0bf66c0797a7f350ff8826a9403f13": {
+    "key": "13308a5dc7d940e46b77cbeedba9548e841f7176654b74dbe5798c6017b737b6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "PeterCxy, эмоции, emodji, япония, аниме, japan, 我想静静, telegram",
+    "nsfw": false
+},
+"a16d0d58ddd03b30f16e87e4381df811": {
+    "key": "a46e9282fddfee4d42232efea3dc58c776349dce416c70054585a6aa17583a58",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "PetiteSugar, Опоссум, животные, Opossum, Oppi, telegram",
+    "nsfw": false
+},
+"a3aa69c60712b4756f25692ecf2a30bb": {
+    "key": "b92fdecaadff806e430d81b6472192cde827a2abc8d4b9f000993c077b63aa49",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "PhilTheOwl, сова, филин, животные, птицы, owl, animals, birds, Phil, telegram",
+    "nsfw": false
+},
+"f8ba88c71f20350753470d36e8c84516": {
+    "key": "a1639f5164369d1f1162ae0f9c27b1a97c22b4c7668b7d8dac48c2cd5a9bc9eb",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Андрей Козлов, Pierluigi_Collina, telegram team, футбол, спорт, чемпионат, италия, судья, football, sport, championship, italy, referee, Pierluigi Collina, telegram",
+    "nsfw": false
+},
+"99e30977ae735912080f1f3b382849b0": {
+    "key": "7c6bae7eb939c80972e6de1b902afaac0a5d868cf0b0daab042eca763e4b3110",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Andrey Pryvalov, Piggy2019, зима, рождество, новый год, праздник, животные, свинья, символ года, 21019, winter, christmas, new year, holiday, animals, pig, symbol of the year, telegram team, Mr. Piggy, telegram",
+    "nsfw": false
+},
+"7d484f627349642fae285eabf9c98926": {
+    "key": "62dac729063187b442eff4c85ac4b113d1157a7cc7d97b6d01b7c0cdf24ca49a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "PikaFlvl, мультик, покемоны, pokemons, Pika Pika, telegram",
+    "nsfw": false
+},
+"b5d885313edf1bbc9e34d91a8257b778": {
+    "key": "3b35d7a5aac111410f3c0e8466b56deab204e7f0ef3194ea36de472932ee1994",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Andrey Pryvalov, PikachuDetective, telegram, пикачу, фильм, покемон, movie, pokemon, pikachu, Pikachu Detective, telegram",
+    "nsfw": false
+},
+"b20fe819e5a54dcd226105a07a056c86": {
+    "key": "34af87ab0f3cf6a25ecda5448b30d5045f8adc645f567af77a6320e9227488dc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, PikotaroPPAP, Pikotaro, pine, apple, pen, PPAP, telegram",
+    "nsfw": false
+},
+"5b374df527aaf0d1c82e6fcb84965248": {
+    "key": "49a30c36d5976bfd52de469a6d2fa77ec4ae344e7ac93a95d9981e9ffaba1b23",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valya, PinUpBabes, telegram, pin-up, girls, девушка, пинап, Pin-up Babes, telegram",
+    "nsfw": false
+},
+"4f2fbe2d4b871e80d9e5a382ef3278ac": {
+    "key": "e7183f940ee9abddd61f02db748e88020a6ec2f52ebcb2174341b20067b010d1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Sia Po, PinkDoll, кукла, барби, блондинка, девушка, doll, barbie, blonde, girl, telegram, Pink Doll, telegram",
+    "nsfw": false
+},
+"c2db3e7500abce93b473dd89fd34eb80": {
+    "key": "0aed871766287195276c54c282d182bc4e40f6e06a7bf1774fa20307d0dfdf7a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "PinkPotato, potato, овощ, еда, Potato, telegram",
+    "nsfw": false
+},
+"e8da4072c99a2b9ee1210de31e6b7146": {
+    "key": "4947e6f2784e8a2806cd5bbefa91c7f5f7713f9e472c23007163eb40f1842e5f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Рута Михеева, PinkPussyCat, животные, cat, cute, animals, кошка, милота, telegram team, Pussy Cat, telegram",
+    "nsfw": false
+},
+"a70eba5485a2ce310708fcefb056d073": {
+    "key": "5e6690ceb049a6d6f249e86814b869d1daf17e9161453764f29965d79ba5db93",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "PinkRabbit_stickers, кролик, животные, заяц, заяцсдлинныминогами, animals, rabbit, Pink Rabbit, telegram",
+    "nsfw": false
+},
+"136f5eec31e19c06c630124e7a591597": {
+    "key": "2f73797fd1a0ebafb4855b620d5f8528047eaff0c947a7c3872bc2bba7eddce8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "PinkiePieDivision, мультик, для детей, cartoon for kids, children, My little pony, пони, Pinkie Pie Division, telegram",
+    "nsfw": false
+},
+"fa58f41595aa60a55a0f59c56ebf7b49": {
+    "key": "18634de66c04aa2c2d872900a9372838184690baa0beb31cf91fd51241c6c4dc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Pintora, мексика, художник, искусство, живопись, картины, mexico, artist, art, painting, paintings, Pintora, telegram",
+    "nsfw": false
+},
+"b0982647951e1528cd60c6a6d54f267c": {
+    "key": "6ccb9ce225c48f4ad1820b13b13b85052de2fadee5654caaf843f39001c518ae",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Pinup_Girl, на донышке, женщина, девушка, люди, арт, искусство, Girl, woman, people, art, Pin-up Girl, telegram",
+    "nsfw": false
+},
+"a6ac05792f13e7a826ed5e40c1d26f2e": {
+    "key": "59a10fb709446038cfeaa5cc804225f8ed036ea7094ec3b9c2d4709065e6b5e1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, PirateRica, пираты, женщины, Pirate, people, women, Rica the Pirate, telegram",
+    "nsfw": false
+},
+"0b79a34ac7a201dc1a5e4bace6337ccb": {
+    "key": "be3db6fbda016a2f305efa21d9ef39014a9fa10294092485123f6320b451dd97",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "WindokiTarot, PixelMoji, смайлики, эмоции, пиксель арт, pixel art, smiles, emoji, PixMoji by @WindokiTarot, telegram",
+    "nsfw": false
+},
+"02db4a3ce5f726f17f7a17d860918c31": {
+    "key": "6d5245c26ceb5debc3ce827ef50419880a11a5ef6acaee472b8bb331bb87cb58",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Саша Ком, Pixelcat, кот, пиксель арт, животные, Pixelart, cats, animals, Pixel cat, telegram",
+    "nsfw": false
+},
+"e566a3e8f13ea56b755ef7e96a654005": {
+    "key": "66ca98202ee071005c421887ad1c14c60f6a6af76fd6e8cb1524c179793c9cc4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Тру Дру, PizzaBoi, еда, пицца, food, pizza, Pizza boi, telegram",
+    "nsfw": false
+},
+"0e2b74c07e9aeecbb1c86e2009ccb667": {
+    "key": "15fda56fa156e43659b45befe33a93a178eaf4f4f55573448765a0644bef59b3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Serbun, PlagueMD, telegram, чума, болезнь, средневековье, ужас, хэллоуин, plague, disease, medieval, horror, halloween, Plague M. D., telegram",
+    "nsfw": false
+},
+"3608140668bab17838e571535d91d9e8": {
+    "key": "b80767590cee531b763088d360466a30e6d0abe1c28c2a952db40b039fa4b97e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Viktoria Moloko, PlayMinecraft, игры, games, telegram team, Minecraft, telegram",
+    "nsfw": false
+},
+"f498fff444e877465d7868b40cd32e4f": {
+    "key": "42cc70e7f57febfef5ee2982baa626e3d70f4ab2662ee5d1d3a9dc3c208d11b0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Revenge Meow, PlayboyGirls, telegram, плейбой, девочки, девушки, эротика, блондинка, рыжая, playboy, girls, erotic, blonde, red, Playboy Girls, telegram",
+    "nsfw": false
+},
+"2108f48eec8ce6cbdb32f9664ee9f5a9": {
+    "key": "f0bb168e1b38741d9ae37d511af81b0a120f88e316aa22d36403e63e9f213ad2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Альфия Сиразиева, PlushaAlfiusha, кот, девочка, животные, люди, animals, cats, girls, PlushaAlfiusha, telegram",
+    "nsfw": false
+},
+"db0bd9d4394104dccff11c4315623099": {
+    "key": "603bb3986db46ab0a0c07b9891ea47c184f343643aa50eab35658071cf1969c9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "PokemonMasters, игры, покемоны, games, Pokemon, PokemonGO, telegram",
+    "nsfw": false
+},
+"8ec32c89a9b357e7be62a10fdd8a57e0": {
+    "key": "368d5d7548dd7654b721966cda142e9c28afbd1113012de067e22c68e3f6d27c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "КиноСтикеры, Polnii_Raskolbas, мультик, сосиска, еда, сосисочная вечеринка, @animesticks :: Полный расколбас, telegram",
+    "nsfw": false
+},
+"b3c5fa1aa70ae468af7ea5e111431935": {
+    "key": "34cbdab073b7ea98bf67579037b5b93d2f9d3b6dd36715ed247662d43d0526c1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Boggart Owl, PopTartCat, кот, животные, радуга, ютуб, cat, animals, rainbow, youtube, telegram, Nyan Cat, telegram",
+    "nsfw": false
+},
+"643796ca5e5399d9d0d0dc0fbc4baea3": {
+    "key": "4b8384c36eeb43c1f33f228ea588240ceed8493307369134e5f8c2b2d47a98d2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Katerina Dudka, Poposo, poop, какашка, говно, shit, Popó, telegram",
+    "nsfw": false
+},
+"05ff818344ba0759069a1c7206700891": {
+    "key": "becf6627063b439f90a108e124d556a100ab7b915b4d75224de260ba21ba4d72",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Vyacheslav Reyn, PornActress, порно, секс, блондинка, отношения, sex, porn, blond, girl, telegramteam, Pornstar, telegram",
+    "nsfw": false
+},
+"b365583aa68a7c0bdd4b3986f5ea93a3": {
+    "key": "2881523c0e5d77cacaab24fa773ef97dbc60ec43276f279d6ee0d8b1adc589b1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mari Inari, PresidentPutin, путин, политика, россия, президент, putin, politics, russia, president, telegram, Putin, telegram",
+    "nsfw": false
+},
+"33e0a0ac5de1716aefea4880ec35085d": {
+    "key": "6b2d615576ac46e2887c226958501ce09ad78f47f269beed01c4f5ac660b3258",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, PrettyLazy, животные, лень, ленивец, Animals, laziness, Pretty Lazy, telegram",
+    "nsfw": false
+},
+"d91b9c59ec10d5714319b4e0b61c686d": {
+    "key": "8e24a3fa7e5488bc73b5b5f7e5f03424d600cc9d3a2de66b560eb36ed27946da",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Aquamine, PrettySailorMoon, telegram, cartoon, аниме, мультик, anime, Sailor Moon, telegram",
+    "nsfw": false
+},
+"1c44befd29a81d368cfbf76f7d3fa1de": {
+    "key": "ed8c9fa5e99c30be4aa1603f74b14cb8e89d4f11a7af468e4aa09634dc18dac0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, PrinceOftheUniverse, принц, красавец, парень, мужчина, нарцисс, prince, handsome, guy, man, narcissus, Star Prince, telegram",
+    "nsfw": false
+},
+"f6348526fee815c3a4e093c0403fc85b": {
+    "key": "68351f10049249cc5260047b5b6ec85de0e4f98699cf917fe1ac46041b257131",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Tamara Gerasun, PrincessLeiaOrgana, звездные войны, фильм, telegram, star wars, movie, Princess Leia, telegram",
+    "nsfw": false
+},
+"105cc08e49b815c18a4d6aec2788eda2": {
+    "key": "5bb28966d4231621dd01679fbe3b1280f918c710e5e4ea5d14266f18f1d704fc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Procy, животные, енот, animals, raccoon, Procyon, telegram",
+    "nsfw": false
+},
+"07bd0991d3732c773fa21dc86e7cf7f4": {
+    "key": "45450bb442103e132d3a89bf00f19ae04e130fc7061a3c63c80b20eb13273275",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Prywinko Art, PrywinkosLife, prywinko, prywinkoslife, funny, anime, cute, womanlife, woman, artist, аниме, милота, comic, женщины, юмор, Prywinko chibi, telegram",
+    "nsfw": false
+},
+"cdec6016f9cfeed0a9c1a7153bf0e108": {
+    "key": "fe223cf22bfa318e565fe9cdfb8143eb21974ed991d90f8f8e5d8a138ce83b98",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Gemma Correll, PuddingTheCryBaby, собака, мопс, Pug, dog, google allo, животные, animals, PuddingTheCryBaby, telegram",
+    "nsfw": false
+},
+"270f03ae486473640543b6570470b77a": {
+    "key": "15416a8b87da13b66469b3eeb415d542ef3cd172f57cafd6be9841fa0c7836ac",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Настя Тёплая, PugPower, мопс, животные, собаки, dog, pug, animals, telegramteam, Pug Power, telegram",
+    "nsfw": false
+},
+"c26731fab6be8c5328a47ba35164dbb6": {
+    "key": "c41dbd24da4640e9f1cd208a4765aacd65eaf18a6b1b8fa2e76a712654610017",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Nadinitter, Pugsly, животные, собака, animals, dog, Pugsly, telegram",
+    "nsfw": false
+},
+"0081ea1cfb2ab4318bbb8c8e0d61de6a": {
+    "key": "27f09fda38a799c6c8cc385a4f47700fc38b8e9e63118f3976ee46e163733ce5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, PumbaTimon, мультик, тимон и пумба, зима, новый год, рождество, животные, хакуна матата, cartoon, winter, animals, new year, crismas, pumba timon, Hakuna Matata, telegram",
+    "nsfw": false
+},
+"c0ac1c76f83d22949e28a8a8bd9fefb6": {
+    "key": "6ffc271bf5cc3523e8e8d36ed770ac01d5df23df467de084d90cd062105e6478",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Maxhasky, PumpkinHead, тыква, хэллоуин, ужас, страх, монстры, pumpkin, halloween, horror, fear, monsters, telegram, Jack Pumpkinhead, telegram",
+    "nsfw": false
+},
+"18664f77647d28bb5d0f1a088211d159": {
+    "key": "642e85aec7c099f4bf3e97a7ed497d70f7f27e873cc9e7efb16f57e8105a0766",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "PumpkinPump, pumpkin, vegetables, food, тыква, овощи, еда, хеллоуин, halloween, Тыква Памп, telegram",
+    "nsfw": false
+},
+"801ea1ffb1117b8653bff8de0a1c858f": {
+    "key": "3eda6b344f4ce7e71354f703f8a464908dcdca660b03dc3c135bb348e54d5821",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, PuppetsDolls, puppets, марионетки, дергать за ниточки, куклы, dolls, Pull Some Strings, telegram",
+    "nsfw": false
+},
+"e698e3db06db84afc17e558f9f4cc337": {
+    "key": "e78d89298d941e050e75c34d13fcf39ff4869a20c9cce6007711b332d8b7b9be",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "PuppyKitte, кот, животные, animals, cats, Puppy Kitte @stickerssave, telegram",
+    "nsfw": false
+},
+"0ca57dfbddb36e108719926b347b8cca": {
+    "key": "64d1be8aaa37230e5777613b81517c25a8b6a2d145180f28129b750bedea0218",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Pusheen_3, пушин, кот, cat, animals, животные, pusheen, Pusheen 3.0, telegram",
+    "nsfw": false
+},
+"649484a1b1f18789cb9d3553fe852496": {
+    "key": "48ebbe4475bb5229f0349c8b15e8bf7addc48ad063022d43648b3d386fa72cff",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "PussieKittens, кот, животные, animals, cats, Fluffy Pussies, telegram",
+    "nsfw": false
+},
+"8125a1fb9c868b3f10d1c8d4d2fbc079": {
+    "key": "65a77a79b07e5fe13301b596b69110e98f58e3262fdda215a627b8102eb30ab0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Qmasjanja, фильм, мультик, QMasjanja, telegram",
+    "nsfw": false
+},
+"f71d1df64dc475991be073b52dd912c7": {
+    "key": "a5065596d6650a2ceea4b55a318775bb26c3c3c584344eff5840f1974fc23abf",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Quaki, птица, birds, animals, животные, Quaki, telegram",
+    "nsfw": false
+},
+"027288d815eb8322ba2e85ae5073416f": {
+    "key": "23613d897b3ff5a06126cdcbdf8c7a1fdfd710f6367fcfdf409a94d9f40173c8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, QueenElizabethII, королева, англия, британия, елизавета вторая, женщина, Queen, England, Britain, Elizabeth the second, woman, The Queen, telegram",
+    "nsfw": false
+},
+"9836c09898352a30953f83ce18aa16b4": {
+    "key": "7d6a2d3acbbd354855ddb72f30cc956e82214f34667b800cfa01bd4264337588",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ilja Shapovalov, QueenOfEgypt, женщина, царица, египет, woman, queen, egypt, Cleopatra, telegram",
+    "nsfw": false
+},
+"3597e38efb8e1d5aebdcf59da35d8374": {
+    "key": "95fde34cc3982b36ac78efa9dcbc991f10b509d8238647020818ba5dd86ee97c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Den Cliff108, Queen_Freddie, telegram, люди, музыка, звезды, people, music, stars, квин, queen, Freddie Mercury, telegram",
+    "nsfw": false
+},
+"b15c51425f9d5677138c630662135fb0": {
+    "key": "1a0a3be6235494ff859a1a11d4f2ec49020f8af716c5050d140e5a1d0cde7763",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valya, RabbitJessica, кролик роджер, who framed roger rabbit, фильм, movie, telegram, Jessica Rabbit, telegram",
+    "nsfw": false
+},
+"442860bba837a6103846884e55bfcb72": {
+    "key": "e279b85458a4f9c628fbc678bcf1f76d845dafd0143dedc75dd766498d40ddbc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Olgabasanova, Raccoon_pack, raccoon, енот, животные, animals, Raccoon_pack_Енотик, telegram",
+    "nsfw": false
+},
+"307746bc431a31466fd1ea9c5c059228": {
+    "key": "e032475a26ab0d710af4bb0bbc516f61d918358e9352b9a7df97df34bafe355a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Стася Лёва, Raccoonloya, животные, енот, animals, racoon, Raccoon, telegram",
+    "nsfw": false
+},
+"2a70bf39c74175083a4479c7e40f8908": {
+    "key": "9f400cfc9ebdb1eb7bbe9b4579305854aad8f75e6813a4a36ef878da99424247",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ira_bob, Racoon_Jessie, животные, animals, конкурс2016, Jessie Racoon, telegram",
+    "nsfw": false
+},
+"f8ff1cefc92ce40671e5e53fa6070247": {
+    "key": "59c55e72144e9324aed96e4a03a4bff02c4edbf5fa5a050f69ed14f81c9aeada",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeria Fills, Rainbow_cat, кот, животные, animals, cat, Которог(@Valeria_Fills_art), telegram",
+    "nsfw": false
+},
+"a0d53f98ff0247b87e317456e343a811": {
+    "key": "78ba8598de6cf89f111b3d92b9fdc9199a6c5b24ef10e8a3c10e0a91f93dc3d5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valery Matyukhin, Ralphs, вконтакте, животные, енот, animals, raccoon, Ральф, telegram",
+    "nsfw": false
+},
+"a5a995dc114a51a1eb1ff7f9c2b86388": {
+    "key": "779da22264496f2be419c891debe00c4fff6764d0f13bf9166ae6314adb05fe3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "alice_socal, Rawpotato, vegetable, овощи, картошка, еда, food, Sweet potatos, telegram",
+    "nsfw": false
+},
+"394925c92390c83027b547b620f1ee30": {
+    "key": "95e7a4c400e26e0baa64de60b01c5a7ffc9fe79d268c7c17c287a9ac96dd9179",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Надежда Паль, Re_husky, собака, dog, животные, animals, Reisenderra's Husky, telegram",
+    "nsfw": false
+},
+"6376c3858e3a2c2a51ccef3794898f6d": {
+    "key": "8ca163298806611867efff83556047d5610568533d62b79070f0d4e2dc006297",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeria Fills, RedHeady, девушка, девочка, рыжая, girls, Рыжик (@Valeria_fills_art), telegram",
+    "nsfw": false
+},
+"0a171d7351acb488051b1b99164e45f1": {
+    "key": "c24ef42c4c5f67e7752e17c73767f83b91b2a3ea9202ece3b8f7c864aa96f614",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Рута Михеева, RedLinx, животные, кот, cats, animals, feline, telegram, Lynx, telegram",
+    "nsfw": false
+},
+"0d183df124ba1fa2c989fcf6908d88ae": {
+    "key": "7a1d55f116d7f872cb87a4a481078eeed8b78507d5ecbfd80e71f11f9f88fa13",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Red_Riding_Hood_and_Wolf, красная шапочка, шарль перо, сказка, для детей, волк, лес, for kids, story, fairy tale, wolf, forest, Red Riding Hood, telegram",
+    "nsfw": false
+},
+"6bceb79f6e851e87aac984a459a1d7f5": {
+    "key": "bb713bcdb7c1eef62625be590a883095632cc4bd4b29f239ed6db725f6f9a209",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Саша Гуленко, RedandBlue, girls, friends, friensheep, дружба, подруги, девочки, Red&Blue, telegram",
+    "nsfw": false
+},
+"20c8ec188f9048a4117dac60df6f7c9f": {
+    "key": "4976db8a79ce2e547df7e10069d6f688ad3e9e1bbc5af71f798708298ed05f17",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "RedandBlue2, girls, friends, девочки, дружба, RedandBlue2, telegram",
+    "nsfw": false
+},
+"67c8d6d9c0d4f5a187326b719a4a5c44": {
+    "key": "f984f5889db25f2a08c36592aa26ade7014bca4194d9b94d20b06f282c3cb4ac",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Stasik, ReindeerParty, новый год, праздник, зима, рождество, олень, животные, new year, holiday, winter, christmas, deer, animals, Reindeer Party, telegram",
+    "nsfw": false
+},
+"8a964af9ce1600222246cc8e190da038": {
+    "key": "893c9959c426cf1c1255a22bcc351f5cb05a36c788d96746ce31dd4f9b82e16d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Tamara Gerasun, ResistanceGirl, telegram team, цифровое сопротивление, ркн, блокировка, девушка, digital resistance, blocking, girl, Resistance Girl, telegram",
+    "nsfw": false
+},
+"997ed704a3dffd5b26a3dbb5ad7fb640": {
+    "key": "3799fed7eb24549d44a262247dcd2e5c7be363e0457cc00183565f03b562aff1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Мухаммад Абдурахманов, RickandMorty99, мультсериал, длядетей, мультик, cartoon, forkids, Rick and Morty @hovert9, telegram",
+    "nsfw": false
+},
+"406bd88dd8ff046eaeec126a9aa91afb": {
+    "key": "9deee5671252a0d39d75c558577d396a7cc18ff26880c6c6ae6645452b97cec6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Наталия Силич, RickyPanda, животные, animals, красная панда, red panda, конкурс2016, Ricky Panda, telegram",
+    "nsfw": false
+},
+"e2742d92da2c9ffa466bff5f352da754": {
+    "key": "0fd7b5d8504be73939a30f247f755a17ad7ed5e2e3e8e62cb246ce5a3ff77df1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Rigga_muffins, кексы, еда, выпечка, cupcakes, food, bakery products, Ragga muffins, telegram",
+    "nsfw": false
+},
+"661da9616012f6318eae4b69410fdb7d": {
+    "key": "af0ade0faa7cf2bbd59db35de4fd4a134bf271ce1f123552615eea9e3ca38b61",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Madina Zholdybekova, Rkzhp, попа, ass, попа с руками, работа, рукожоп, дороги, асфальт, стройка, Ruko, telegram",
+    "nsfw": false
+},
+"fcdb80176c3c2142a9b00fd4da9b095d": {
+    "key": "51002a94b6663ba4db5b2317446dcd3c916978dc7c288ee72ae0d6736b099344",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mary Virgin, Roger_Smith, американский папаша!, american dad!, series, cartoon, мультик, сериал, telegram, Roger Smith, telegram",
+    "nsfw": false
+},
+"5788fd3e0511f22543a6716ab5a55e18": {
+    "key": "692f273720847a5b3aebe32e7ad0c8cb0da50c08543551e9e210fbda525b6cfd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, RomanticKnight, отвага, смелось, рецарь, конь, среднивековье, кони, сказка, Courage, laughter, a knight, a horse, the middle ages, horses, a fairy tale, Romantic Knight, telegram",
+    "nsfw": false
+},
+"acab5fbeff197fe6f9fd0552eb0f7d6b": {
+    "key": "a3f2f1dd5ed7663194d432231af1661ef907b2bf600bb5a24a2e97081d86bc90",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ronas_IT, программирование, осьминог, животные, programming, animals, Ronas IT, telegram",
+    "nsfw": false
+},
+"c8f8b06977fc73f36bb1a8efdab6827a": {
+    "key": "da9211d738a4806ba7a64ad6ed96a4e03686c1a8ec473f0fbb1e28feb2212d36",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "NTLENT, RottenRobbie, лентяево, lazytown, фильм, сериал, персонаж, film, series, character, movie, telegram team, Robbie Rotten, telegram",
+    "nsfw": false
+},
+"95773c084c2cec14d5931705f0069ea8": {
+    "key": "b7e6f64effeba17d6a722438b65a542cad1b9cc70bd8112f5ad802fa5f76f5fa",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Логинова, Rukitoka, девочка, девушка, клоун, цирк, girl, clown, circus, Piero, telegram",
+    "nsfw": false
+},
+"f44ed7e3688ba710cda73c4c7ea7c8c2": {
+    "key": "10bafe407b62d58969e43501ffbdb7cef1e539dda3d055cca7e2c27943bc3cf9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "RuntsAnimals, animals, runt, карликовые, коротышки, Runts, telegram",
+    "nsfw": false
+},
+"80582d565a0d486aebc42e8202eb079f": {
+    "key": "035dd6255528ababbda0df629a89c390e1f388ab40cfd93c26378fedf1f2cf84",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Alexander Sorochinsky, RussianMinds, гоголь, пушкин, булгаков, чайковский, толстой, достоевский, бродский, поддубный, маяковский, гагарин, менделеев, королев, ландау, яковлев, павлов, великие умы, россия, ученые, писатели, Gogol, Pushkin, Dostoevsky, Bulgakov, Chaikovsky, Landau, Mendeleev, Pavlov, scientists, writers, Russian Minds, telegram",
+    "nsfw": false
+},
+"b7e0a2558a9eab5780c432bb33b31d8c": {
+    "key": "aaf937fb8fb221256fb8d9a07d2d04f5f9375def5df626eef3f0c3f94e6a620e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, SadBlobby, рыба, fish, животные, animals, Sad Blobby, telegram",
+    "nsfw": false
+},
+"1c7c584b3574be885a70e3609e11336d": {
+    "key": "f94930c2134e2cf9f5fcf8a52f565e24c80880294b0b53093f796fb0a49d051c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Vyacheslav Reyn, Samurai, япония, борьба, самурай, combat, telegram, Samurai, telegram",
+    "nsfw": false
+},
+"b94ebbe2dbd956e52887e2acf4becba3": {
+    "key": "d0f451647cfaae6c6338d682a4f77672a8def2e4af5b9756f6f3dfb7b20d0717",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Tamara Gerasun, SansaStark, игра престолов, game of thrones, сериал, series, telegram, Sansa Stark, telegram",
+    "nsfw": false
+},
+"d471764cf14dbb348326acfe7f1e01b4": {
+    "key": "e9756c9de1d0050de49373862adfb459f72006a4ba1fcb501dde10b9a36accfe",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valerie Fortuna, Santa2019, новый год, праздник, зима, рождество, санта, дед мороз, new year, holiday, winter, christmas, santa, Santa Claus, telegram",
+    "nsfw": false
+},
+"7c612be480ae9c690d12db46dd291688": {
+    "key": "afed488862877939cb13c42ef2eaac4596d20e3f355ff1ff4128c8fa6ec6cf55",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Tamara Gerasun, SantaGirl, дед мороз, санта клаус, новый год, рождество, праздник, santa claus, new year, christmas, holiday, telegram, Santa Girl, telegram",
+    "nsfw": false
+},
+"e15e1711ef870b0893ad2771d67bebc5": {
+    "key": "42244c57e55505fbe95aadf115e375f36681ad7f22b512e023e1445eabe9898f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "namiharinezumi, Sasbalas, ёж, животные, hedgehog, animals, Sasbalas, telegram",
+    "nsfw": false
+},
+"423e75a5787ba944cd886f2e0af0cdb9": {
+    "key": "688fe3ae9a148865a192f0a4b64cfd2e16bf601a5669a63ccdb8a7adae6fb56a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "TeDDy_ooO, Saturnela, девушка, девочка, люди, girls, Saturnela, telegram",
+    "nsfw": false
+},
+"21e54d5a791b0840cc364581f79e9114": {
+    "key": "9731e6a05b1df61cb6f6ab3dfa79723fa948739899888e26fb48b5527c3a1ba1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Saymoor, кот, животные, милота, cat, animals, @kotstvo Кот Сеймур, telegram",
+    "nsfw": false
+},
+"5cf9b98e3fd0519ca581f6e2049f3079": {
+    "key": "92bc57a89b19af8ce66435447bd164bd943d94747090618c9684383012ffe8a4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ScrambledPenny, яйца, яичница, еда, food, Scrambled, eggs, Penny Scrambleton, telegram",
+    "nsfw": false
+},
+"fdccfe42ce6ef68e05c144934d97fd01": {
+    "key": "f6b51d9433f03a210d383236f72f398266e216d1743fb8c187d971e8af3eeac1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Scream_Movie, фильм, хеллоуин, смерть, ужас, movie, halloween, death, horror, Scream, telegram",
+    "nsfw": false
+},
+"77d527f3c6c8a6f54a918a2fd907af5c": {
+    "key": "e482f31c498fa438f320d02b6bb1021e33ea828daa7fbad5427c256814f447e5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Рута Михеева, ScreamingChicken, курица, chicken, toys, игрушки, telegram, Screaming Chicken, telegram",
+    "nsfw": false
+},
+"21adaafae0edf054b4595243a918d8a5": {
+    "key": "b1c6015aba8d8008ba87427f51af840be144184f3b3db82aff75cc8278ab59be",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Marc Johns, Semsentido, арт, сюрреализм, surrealism, art, Nonsense, telegram",
+    "nsfw": false
+},
+"fd06a9d97dd08bf4f36c786ad4f1708f": {
+    "key": "1f5533904a853860033a648fba999035d7b7b1fa2a7539af3415251a99522c59",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Kiselmix, SemuxPack, деньги, бизнес, money, buissines, Semux, telegram",
+    "nsfw": false
+},
+"13a6bd6ecbdfa4de4dd6aecfb48e6ac3": {
+    "key": "eae5099a9a72855335717a03f7fe4cd1de2b952d16c4a4605609a8bb7353ef70",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Анна Шумская, ShakespearesTragedy, telegram, любовь, отношения, романтика, 14 февраля, день святого валентина, фильм, любовники, книга, шекспир, love, relationship, romance, february 14, valentine's day, film, lovers, book, shakespeare, Romeo and Juliet, telegram",
+    "nsfw": false
+},
+"c5fb525dfd1fcfa33dc3464434c17481": {
+    "key": "d49b38400e27a5b29cbe6d1d00b279a86530efc2e19fbba656a02af3016d5d55",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, SheikhIt, араб, саудовская аравия, шейх, Arab, Saudi Arabia, Sheikh, Shake It!, telegram",
+    "nsfw": false
+},
+"6233322e59a3bc21b2f1f1f7cafeaaa4": {
+    "key": "35ac31f16a0d4969d97b5b06a6944395fb18ac89147e7d6f8926aaeb5c4c1955",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Snowy Jellyfish, SheldonCooper, теория большого взрыва, сериал, тбв, the big bang theory, bbt, series, shows, tv, telegram, Sheldon, telegram",
+    "nsfw": false
+},
+"08f7c55133380928517f9afb0c3c1eca": {
+    "key": "e95f0bc2ecb6dc4c6eb8c5cf86d862b903d081bf12fae45309a898ec2fb2866a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Aiko Kuninoi, Shiba_Inu, собака, животные, dog, animals, Shiba Inu, telegram",
+    "nsfw": false
+},
+"92913b5096ae2eaf00e48bc4da0779fe": {
+    "key": "95915416dcf28b0c227fdb2adbb45c7e4b60f36485eec7067ecc2f64cb074c1f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Stasik Screams Internally, ShiverMeTimbers, пират, сокровища, море, pirate, treasure, sea, telegram, Shiver Me Timbers, telegram",
+    "nsfw": false
+},
+"9aaa71b2b847eb1393b0cbe46443c082": {
+    "key": "6370d1cd7e2cf149e949b9d7915aca1740f415182bbec0df906b3c7291e13665",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Shortnameforstickers, животные, animals, Animals?, telegram",
+    "nsfw": false
+},
+"1350d84b80f4584c0c665af4a51a88cb": {
+    "key": "3a72e01afdadbcfa946f43c76e52085c398b4919c804ecbffae89ac5d5b3be6c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, SiameseKitty, кот, кошка, животные, сиамская, cats, animals, Siamese Kitty, telegram",
+    "nsfw": false
+},
+"030ea6b1931bbf765cf08f7aa4a3c0d9": {
+    "key": "0a00bb9c63353d2ce31ed6a0fcdf98df59ee63ce396dba47f760e7011b63b803",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, SigmundFreud, психология, наука, надписи, психоанализ, psychology, science, writing, psychoanalysis, ученые, люди, scientists, people, 14 февраля, день святого валентина, любовь, секс, sex, Valentine's Day, love, relationship, Sigmund Freud, telegram",
+    "nsfw": false
+},
+"648376d76011483597c841c07fd451fb": {
+    "key": "9ae6350b7a4d88b756fd64b8075e45d64a72d7b8d9a0af450875461f7b686821",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, SignoraBellucci, bellucci, италия, люди, актриса, женщина, italy, people, actress, woman, Monica, telegram",
+    "nsfw": false
+},
+"7fa700b10c2c0deb9d41e2442a7a940f": {
+    "key": "a3b85b80af3126afe60a0381aa90b36d9e0da70bd37d3af65b937d0f2dec44dc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "NTLENT, Simba, лев, lion, cartoon, король лев, the lion king, мультик, длядетей, telegram, Simba, telegram",
+    "nsfw": false
+},
+"63a3921d0464e7a46b2fcbdac1cc5f27": {
+    "key": "9c58b4a100bde7d48ab2438d8cf82a31f7cf7bdd9a3668f5747a85dc16ce1221",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Simpals, смерть, ужас, хеллоуин, страх, death, horror, halloween, fear, Dji's world, telegram",
+    "nsfw": false
+},
+"b6da52f7b093464740dce8f26cd6baa7": {
+    "key": "283a7461b18396fcdf355a617ab5eedf9f69dd626ccab4089333b44bdfaa8cf4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Carolina Dargel, Simpik, животные, animals, Simpik, telegram",
+    "nsfw": false
+},
+"6770140615f2921c3abbcf4ff86eba60": {
+    "key": "45e8250bc503468bab6e3b3d94f3e638a903d5d0aa8d83f68b8d20bc37635408",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Наумов, Sindron, чудик, монстрик, freak, monster, SIndron, telegram",
+    "nsfw": false
+},
+"f47bcff0c3bff506961a322b0568d936": {
+    "key": "06d245f6396d8f2043ffa3a7a635d63ebb2d817fae0aa7af687fa1369f517c66",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeriya Sikorskaya, SirenInLove, любовь, отношения, романтика, 14 февраля, день святого валентина, русалочка, рыба, девушки, love, relationship, romance, february 14, valentine's day, mermaid, fish, girls, Siren, telegram",
+    "nsfw": false
+},
+"7ed1c7e26f18e79582d0a4cbd91824cb": {
+    "key": "01c12449c2b2d68b647d297ce297514973689804f83a86ff3bdd3c660882a181",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Skeleton_Bob_By_OsmerOmar, люди, скелет, кости, bones, people, Skeleton Bob / By OsmerOmar, telegram",
+    "nsfw": false
+},
+"eae8f34492fae3348987ec185422b6cb": {
+    "key": "4b6c84bc6085cd15d184fe825a6d49b3f5ea64b659dd0f8d8246acbbf146f087",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, SkepticalDoc, доктор, врач, медицина, больница, Doctor, doctor, medicine, hospital, Skeptical Doc, telegram",
+    "nsfw": false
+},
+"8fe78c2346fa53afcbf1029429ade482": {
+    "key": "8b01eeb4aa521313391bb57eff4759ac46ab3a85054047b0706b2942638327a8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "SkinCat, животные, animals, cats, котики, skin, telegram",
+    "nsfw": false
+},
+"3c9b8497e079916c871a288dec40b8b1": {
+    "key": "db0171f940a370b552b325e1999ef614d7f3537ca91ecfe375d97e4977794e13",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Антон Андреев, SkinlessDavid, people, люди, Skinless, мышцы, без кожи, Dave the Nudist, telegram",
+    "nsfw": false
+},
+"6220b567e4c0eb1fc99da586ed9a7d55": {
+    "key": "7898dd3805cdcb3d5f4fa6bf3bd1da1d26ff4bfd8e5a601f8447ac3c64742917",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ulyana Tkachenko, SlimerGhostbusters, ghostbusters, охотники за привидениями, приведение, фильм, слизняк, ghost, movie, slug, telegram, Slimer, telegram",
+    "nsfw": false
+},
+"aa2fe4fedd0d86b9948b8a3a526d3c75": {
+    "key": "644973f7f051aa05ebe3e6f442bc303b6e8b1af1ad61d6d3b5bd94bf6d94c895",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Flaticon, SmallDino_byAlexzhdanov, динозавр, животные, милота, animals, dino, Маленький Динозаврик @TuristasTV, telegram",
+    "nsfw": false
+},
+"8b0698cbdc8ad3f12d1553f07d885ebd": {
+    "key": "2a6eb8562e7d3c414642b90a40789ba8f3efba0c8f0412c362a5b5f6f1e514ed",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, SmeaGollum, властелин колец, фильм, хоббит, моя прелесть, lord of the rings, film, hobbit, movie, Gollum, telegram",
+    "nsfw": false
+},
+"7e4b6802379ed834c0f3147ba6be5f4e": {
+    "key": "4845848f269887e6f8d6c8ba5998712769124ac115a6f4763a0ccdeef03444ea",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "SmeshBarash, бараш, мультик, длядетей, смешарики, cartoon, forkids, barash, telegram",
+    "nsfw": false
+},
+"15ab0075c87a9ec3553d4c9e074fe39a": {
+    "key": "b4056a319a9deecfe33b275de384ba955351a2abe9a296ec410ab643e9cbde3b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Artem Vasiliev, SmeshnayaSemya, sitcom, series, Simpsons, ситком, сультфильм, cartoon, Симпсоны, telegram",
+    "nsfw": false
+},
+"d044eaca4d78cd2a44037c91fb4db410": {
+    "key": "f72c304bbb2f637a1c391db03479cd49290da284120576a927a00452f2184e30",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, SneakySnakie, змея, животные, рептилии, snake, animals, reptiles, Sneaky Snakie, telegram",
+    "nsfw": false
+},
+"c4d1211ce4b0070b064ff547210fbbf8": {
+    "key": "378d2936b3c8914d98f067da65d0c888d8aa66e1bfff5d684d2a780af141e543",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Line, SnowMonster_byAlexzhdanov, монстр, эмоции, monstr, Снежный Монстр @TuristasTV, telegram",
+    "nsfw": false
+},
+"fc5c1a4de702ff3c420793520f045ead": {
+    "key": "101600eb8b433dd6f4246dc609c96c3d137b19d4b99b04e5b7fd79f976170e45",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "AnzhelikaJoy, SnowQ, новый год, праздник, зима, рождество, сказка, снег, королева, new year, holiday, winter, christmas, fairy tale, snow, queen, telegram, The Snow Queen, telegram",
+    "nsfw": false
+},
+"99e0c206540803dfc476c9c7fb1dd060": {
+    "key": "5b1d0ad1818994e382840a86133087086bdd0fec91c53324fdd4b12cf1d48910",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Krasivon Art, SoccerWC2018, telegram team, футбол, спорт, чемпионат, болельщики, football, sport, championship, fans, World Cup 2018, telegram",
+    "nsfw": false
+},
+"6236f45ff7bc46d5e14fa1fabde6fc62": {
+    "key": "51c86983d28a504fa9735bc26225ace47c293ae8ca8994bea619bc8a178b9aa5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valya, Sonic, игры, games, telegram, Sonic, telegram",
+    "nsfw": false
+},
+"84946f61c0a2984f96cf1a8f77740b88": {
+    "key": "100032527e27cee6b048341987d24063ca9d5a721eb7ed63c4c50f2e8b2c2ad9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Карина Ли, Sova_Sofa, сова, животные, птицы, owl, animals, birds, Сова Софа, telegram",
+    "nsfw": false
+},
+"663e6bb8128baa9d10b3772de36d4454": {
+    "key": "e18e59f69faab86373ca2751e3d1c12cd8a132643c8db2e74bb76a4e6c1bd6ca",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Корнев Иван, SpaceCats1, котики, космос, животные, кот, SpaceCats @StikeryTG, telegram",
+    "nsfw": false
+},
+"071eea6cdbd62422c85c7bfed66fb1c4": {
+    "key": "16c6c7739ad01e06204428c23938ada9af8c65ac5a78b220e7ce69d5dfd72f38",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "SpaceKitties, кот, животные, космос, cat, anomals, space, Space Kitties by @spacejournal, telegram",
+    "nsfw": false
+},
+"09cd845cd9c8e6ff1ac36d860aa4194e": {
+    "key": "d217ef49437c81d3e8ec687ac100516e8c097ff3a3e753e49168594852f4870d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mokona, Sphericalfox, animals, fox, животные, лиса, Spherical fox, telegram",
+    "nsfw": false
+},
+"ab7c1d081f3b90f1af1674c2af5d1f22": {
+    "key": "8c44677761a3560a482aa2bc8a66b27979fd534ac4c34484cb5b8c04e8c041e5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Revenge Meow, SpiderVerse, человек-паук, spidermen, movie, мультик, фильм, telegram, Into the Spider-Verse, telegram",
+    "nsfw": false
+},
+"1134f259dbf082dcb5c4147ed0a12b2c": {
+    "key": "bc5d272f1d51e85a49d0cd872a9ae1160e60f20116b7f5292050a80497f1a7ff",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Spider_meme, мемы, memes, Spider Men, спайдер мен, фильмы, movie, человек паук, Spidermeme, telegram",
+    "nsfw": false
+},
+"80fdb4f74d04023a589653ab3b6a4430": {
+    "key": "a3608769b80fc74ec485719a2e5589c4f9f01b02828da7f5d2a3fcbfd8ec70f1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Spitz, животные, animals, собачка, dog, конкурс2016, Curly the Spitz, telegram",
+    "nsfw": false
+},
+"e21e783245d136ed7e029a63ec5c838a": {
+    "key": "97d16313e39fe6bec24d1fecd6e89f7a046c5e045f61c752b6c3825a99dad64a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Андрей Козлов, SportGuy, athlete, pitching, sports, training, спортсмен, качок, спорт, тренировки, telegram team, Sport Guy, telegram",
+    "nsfw": false
+},
+"c913ea2139d0ccba9b51c6de9285e406": {
+    "key": "c681896256486460174ccfc658cde3ec090665ee7106808d38bb7eb44a826738",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Светлана Войнова, StTwink, chatwars, игры, рыцарь, чатварс, games, sttwink, game, knight, StTwink, telegram",
+    "nsfw": false
+},
+"c62d4c03f79cce3b5d209895cfef0d9b": {
+    "key": "775b60bf21042156b5043cc17f960bcee23d5ef65c74737ed5ae11587336f61e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mari Inari, StarmanMusk, люди, космос, америка, маск, ракета, тесла, спейс икс, people, space, america, mask, rocket, space x, tesla, Elon Musk, telegram",
+    "nsfw": false
+},
+"829d51cfb52559b439021a68892bd4cf": {
+    "key": "6c15909e8b0e38a939996d62ef98aaf38579820af0ae85eb8e71b97c56827f5b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Anastasia Koschevets, StayFit, telegram, спорт, тренировки, фитнес, стройность, диета, правильное питание, sports, training, fitness, slim, diet, proper nutrition, Stay Fit, telegram",
+    "nsfw": false
+},
+"76500b35a3240d8c1e6de25cda850dec": {
+    "key": "9857fcb049f42452711b5832c072cd86f7cf54048064e7d70a8709531bc861c1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, StaySpooky, смерть, ужас, хеллоуин, страх, Death, horror, halloween, fear, Stay Spooky, telegram",
+    "nsfw": false
+},
+"a2ba813c2677d1bf7f0d20bf8f4b8b72": {
+    "key": "6da2d5dae66b4943a8e96347d28f573a09ed223b57c1ffa6ee18e0efcc993e60",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "StephenButt, степа, попа, жопа, прикольно, смешно, Stephen the Talking Butt, telegram",
+    "nsfw": false
+},
+"f0e94786d8f80c000463e39397ca97e1": {
+    "key": "4ef51d8c7ef43568748a1a489bb223f9fab8c5b0cc723d4e982dadfbb22dc469",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Анна Прохорова, StickersSuicideSquad, сериал, tv, series, Suicide Squad, telegram",
+    "nsfw": false
+},
+"e7e2349e8a730080aae52439aee56827": {
+    "key": "8e64c348b1f2b0ff4cd36e085f05ccec69afd4e9759d8836a9e9825ca9a627a6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Boggart Owl, StolenXmas, мультик, гринч, новый год, рождество, праздник, cartoon, grinch, new year, christmas, holiday, telegram, Grinch, telegram",
+    "nsfw": false
+},
+"bad7105b3b3a2c20e841a9d7275b3aca": {
+    "key": "4dfa5a4572b401bc63859b07867b921e44938ea5e2c190897e8864838a232ca1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, StoryOfLove, любовь, отношения, пара, 14 февраля, день святого валентина, парень, девушка, love, relationship, couple, february 14, valentine's day, guy, girl, Love Story, telegram",
+    "nsfw": false
+},
+"748939a57532709077a5ffee22cce120": {
+    "key": "72ee6dc83402e0f1adeaf4de3a801a9b10ff36a1ad96326f7a5c06c72e5126d9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Krasivon Art, StrangerThings, series, telegram, сериал, Stranger Things, telegram",
+    "nsfw": false
+},
+"c12305178cb219a679734f8628e38659": {
+    "key": "4ccc323d2a90e8076771356b06699c78a7080b4eb9666e60b2c8dfde6ab0c5d8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Konstantin Brilevsky, StripedCat, кот, жиыотные, рыжийкот, cat, animals, telegram team, Striped Cat, telegram",
+    "nsfw": false
+},
+"a8f39f30597986a8711f653d29a388fe": {
+    "key": "85ab915abd873749d96b1ba9c8a25e0e15c154b18b74d5a75785bca10f74f507",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Studio Limb, Studiolimb, робот, robot, Studio Limb, telegram",
+    "nsfw": false
+},
+"a1327b20644539dc5b80bef1b57de1c2": {
+    "key": "f58bfa5680957eb05e896b15a77d6e35e0cd023335bff0ee3ee7dfa6c6532c43",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Корнев Иван, StupidsDogs, собаки, животные, dogs, animals, Stupid Dogs @StikeryTG, telegram",
+    "nsfw": false
+},
+"4e54268f81709aa015995dcd1d127e24": {
+    "key": "1de831420042e82069eb4ccbb384e0f941c58cd7ce1544a9f58b5d292e9c033d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Yulia iulaY, SuchAGentleman, отношения, любовь, relationship, love, мужчина, Such a Gentleman, telegram",
+    "nsfw": false
+},
+"45ac1022df90462a4048caec035f262c": {
+    "key": "847374d915c6ba2431101550998855c35bc8906fe12dfb92752917ab65da97bc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Yulia iulaY, SuchALady, telegram, women, love, relationship, отношения, любовь, женщина, Such a Lady, telegram",
+    "nsfw": false
+},
+"d16e8306b7455d87ce735341a34d2a4e": {
+    "key": "7b0e2bff891736b8a6e25437f87ae666f8240019e90df7f6799a43dca5b331b8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Yana Goga, Sun_YanaGoga, солнце, лето, природа, sun, summer, YanaGoga_2:0, telegram",
+    "nsfw": false
+},
+"2f3c734c867be429274d2da52018292b": {
+    "key": "f60138570313f0adcef4431a5a23c775985447c538655ed5a6525358a3052b16",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valerii Matiukhin, SuperMarioStory, марио, игры, mario, games, characters, персонажи, telegram team, It's-a Me, Mario!, telegram",
+    "nsfw": false
+},
+"5ef2e93c542e6aa9f3c7b67ae1fe6b1f": {
+    "key": "35a64566439c3b2d600e028382ac4d044084df80e6cc321a259ecb43edfa3668",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Вишневская Виктория, Swebushek, паук, spider, хуллоуин, halloween, Свебушек, telegram",
+    "nsfw": false
+},
+"2e273c6b3000d50b55af6686d5511c3b": {
+    "key": "d016097c20c8851cb773c71511735bb4e6cf57fdc3208c42c5a9dc5532745d5b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ilja Shapovalov, Sweet_By_Osmer, вконтакте, девочка, люди, people, girl, Sweet, telegram",
+    "nsfw": false
+},
+"013aade0639013758cf089c306324ed5": {
+    "key": "902b80f2dce29eaa1c51fb53d7c5945dde245d010a21ace87dc0c010ade5c10e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Sweet_dogs, собаки, бульдог, животные, bulldog, dog, animals, Бульдожки, telegram",
+    "nsfw": false
+},
+"7b776d8201d1c3af853fa418a50f96a2": {
+    "key": "592b537d4f676c88c233312e3af11760bfd18974a4bf4eae76209f14139365e3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeria Fills, Sweet_hyena, гиена, животные, valeria fills, animals, Sweet_hyena (@Valeria_fills_art), telegram",
+    "nsfw": false
+},
+"5dd698ea2a93a8fefc90d489e5150579": {
+    "key": "4a5563bf0e7e53d53bd32a2d110a9987d7fdfee2dbec3b0f559c18f957445b3f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, SweetyAnimals_byAlexzhdanov, няшности, мимими, животные, щенок, кошечка, сова, улитка, солнышко, радость, animals, Милости и няшности @TuristasTV, telegram",
+    "nsfw": false
+},
+"22e30f57ff7db8525c22e400d642feb9": {
+    "key": "c1ffabb06ffbba693af33e495e40438015f139d403b34103f85c4b56aeee0b44",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, SweetyKitty, коты, кошки, животные, animals, cats, Catality!, telegram",
+    "nsfw": false
+},
+"00e1d58fbbbaee5a2c0c2bceb0357a31": {
+    "key": "f952f4e89ef50191be1ad5afe171bd0f8e2f9f5891f2dceeefff2e434ec2fd74",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "SwiftTeodorCat, кот, животные, animals, cats, Swift Teodor Cat @softwareports, telegram",
+    "nsfw": false
+},
+"55e7ac9055ff494691e95a159220ea20": {
+    "key": "b9d422f788f625216ca1b6cef029f669727cb59e94977267f2ebe67c94e112d1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Антон, TONYPICTURES, тони, парень, men, boy, TONY PICTURES, telegram",
+    "nsfw": false
+},
+"50e90a26c8cf597f0ab286cdf51438bf": {
+    "key": "4f86655f681eff12de6dfb4981330903054c2e60c048b21854132f43d25f047a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Den Cliff108, T_800, telegram team, фильм, кино, film, movie, Terminator, telegram",
+    "nsfw": false
+},
+"f9a02b8d47b5d68d1691f8197863812b": {
+    "key": "f14c7184f479a154862b9394a91d9831c82245cf3f1676107e5d36543891322b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "TakiDaStickers, одесса, фразы, юмор, Таки Да Стикеры, telegram",
+    "nsfw": false
+},
+"1d6517b935d60a4479d41f2e801a305c": {
+    "key": "4d5bcb449fa89667b68efe17915b4d0c6b2cd7f8d90d4e991b93add676535cd6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, TarantinoMovie, Криминальное чтиво, тарантино, фильм, кино, актеры, Pulp Fiction, Tarantino, Film, Cinema, Actors, Pulp Fiction, telegram",
+    "nsfw": false
+},
+"66c1d805ce1cc528123c91a7ea9cca2c": {
+    "key": "146fca994ae9f3107cb79a67b2a73bff6bac6d937368ca49f426e0d22ae23169",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Serbun, TarantinoQuentin, люди, фильмы, режиссер, people, movies, director, telegram, Quentin Tarantino, telegram",
+    "nsfw": false
+},
+"7c4c8843539bd015ad59aabf2d501a3d": {
+    "key": "492ec6d7daa341edc327a7cd7c45e223ede4a13030f23071b7bb63f0c62cd6c5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Оля Джиоева, Tcipa, birds, animals, птицы, цыпленок, животные, Цыпа, telegram",
+    "nsfw": false
+},
+"ec1a656ea7e5f48c08a686d05174e8af": {
+    "key": "99cee828857191cae2d656db863038c9b05045e36e765dce1d679e5de9a0209f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "TechnoMasks, техно, маски, очки, противогаз, надписи, spectacles, mask, TechnoMasks, telegram",
+    "nsfw": false
+},
+"d09106eec600195c33ab9f23520a9fcf": {
+    "key": "237ce3f2ecaa3c31dc93a16c5ea9ae8725eecc5fad3d4a5ae358477e542e3371",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Darya Ogneva, TedTheBear, медведь, животные, фильм, movie, bear, animals, telegtam, Ted, telegram",
+    "nsfw": false
+},
+"52e35b8c8f9b390870152390a2486b91": {
+    "key": "b967b4389c014f5d1b41a1e1aed8a54a46579aa2c9e65c08665d0a1f4105850b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, TeddyBrown, животные, animals, медведь, мишка, bear, teddy, Honey Bear, telegram",
+    "nsfw": false
+},
+"c7d2e4d268a3c4ba92c433030644d245": {
+    "key": "8745a4f1109c329a137b46760484dd40381b76c3be64b5e6d26a2e84401a9af2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Dima E, Teletubbies, тинки-винки, дипси, ля-ля, по, сериал, tv shows, series, for kids, для детей, telegram, Teletubbies, telegram",
+    "nsfw": false
+},
+"7000eb528ce2eb26fe1c403b811ca35b": {
+    "key": "4fd5f64e0deee865b18681c76927a6e839855528a4a356b991730b54796c6589",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Serbun, Thanos, марвел, marvel, комиксы, telegram, Thanos, telegram",
+    "nsfw": false
+},
+"747d858f78fab41ebe8302c10f1ea4d5": {
+    "key": "626890d1b58cd2ac069932002d8e371f977447ec19a6cbc019019bccb677ff09",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Krasivon Art, TheAddamsFamily, ужас, фильм, сериал, horror, series, movie, telegram team, The Addams Family, telegram",
+    "nsfw": false
+},
+"7e6d6a30da712421ccc75fe51e9b15be": {
+    "key": "6547edb474448604365e3399c057df3ac008ec904f274ee382db5679d57d0064",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, TheBestDeadpool, фильм, movie, Deadpool, telegram",
+    "nsfw": false
+},
+"eb5f831f77dcedd1e6dac40ad8b19392": {
+    "key": "1ec21d03c48295b396fd142e8e1c905e813dc837fdd213fc7764afe682daabfe",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, TheBestMovie, фильмы, сияние, маска, люди в черном, пираты карибского моря, джеки чан, герои, актеры, movies, actor, Cinema Male Heroes, telegram",
+    "nsfw": false
+},
+"fc6ed3134dda27641227c7b0593bb14a": {
+    "key": "abad077a0ff2cf3f932985151980e4fb8472778dcd2ef07c08a513634c2f6dcd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, TheBestMovie2, фильмы, актеры, actors, movies, титаник, семейка адемс, мерлин монро, сияние, одди, Cinema Female Heroes, telegram",
+    "nsfw": false
+},
+"82a50c5a4d709e16a3a8953164721f05": {
+    "key": "84c5b482485890e2951e18100cf99772992f8604ab502c04336084ff8fd950a0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, TheBunny, животные, кролик, animals, bunnny, зайчик, Not Your Bunny, telegram",
+    "nsfw": false
+},
+"119b03cf2799a114c8edd5f6748a494b": {
+    "key": "7947890c3415ac537745fb0d43c824e4ae9c8a417c38926d2facd354cdb9f6a0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, TheCallOfCthulhu, ктулху, монстр, лавкрафт, Lovecraft, monster, Cthulhu, Cthulhu calls, telegram",
+    "nsfw": false
+},
+"fd6eb123ebfed1c0062040addb203473": {
+    "key": "4fa95eb6f3a92e05a0fbde9983cd057ea21694f0bf5b685b83b47256a37933b0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeriya Sikorskaya, TheCheerleaders, спорт, мир, болельщик, sport, country, world, cheerleader, страны, telegram team, Cheerleaders 2018, telegram",
+    "nsfw": false
+},
+"4cec90df5965f09bfa5728c2806bb970": {
+    "key": "86c67a4ec46d665ca23309a3128488ef7f36154d5b0a0dc5d3b6a9298af05137",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "TheFennecFox, лиса, животные, animals, fox, The Fennec Fox, telegram",
+    "nsfw": false
+},
+"97475dc9647fb2261b2f072df46d8e33": {
+    "key": "2c64e26579c968fb58ba9936a2b9381b12161573dfaaf54c854ad47271a74cd6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Vyacheslav Reyn, TheFootballSupporter, telegram team, football, футбол, спорт, sport, championship, fans, чемпионат, болельщики, Football Fan, telegram",
+    "nsfw": false
+},
+"b8a574879f30efa717fa57cc9cab66c4": {
+    "key": "b96c3acada1be4fe54af595aeb36c315377d4e0fdeae681b44d04273fa7f7d6c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Revenge Meow, TheFoxSays, лиса, животные, fox, animals, telegram, What Does The Fox Say?, telegram",
+    "nsfw": false
+},
+"ba70ad336ca7103e0b4effcee8ed1630": {
+    "key": "9acb6af4de60555124d7ad0d1fec7dfd0096ccd42655856072e5ec97cd2cb032",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, TheGloryOfSatan, животные, медведь, bear, animals, слава сатане, TheGloryOfSatan, Kumamon, telegram",
+    "nsfw": false
+},
+"b6fff0e3a9fa8852bbca3917eeec060f": {
+    "key": "2f810f147abcb4a5dd7c2c790986c7ea99867f13129c40eaf9b8edda7a0f9ed0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "TheGopher, животные, animals, Gopher, telegram",
+    "nsfw": false
+},
+"44f3ecb93f9a629c1f9830c3f21898f8": {
+    "key": "7c8b2cee76a8eb89b0a10a5bf78835e9285cee658f722bdc9a9623d87b20342c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Vyacheslav Reyn, TheGreedyCapitalist, банкир, деньги, бизнес, богатство, banker, money, business, wealth, telegram team, Capitalist, telegram",
+    "nsfw": false
+},
+"61b1982a10841e014fe71f326d07fa65": {
+    "key": "8549ec076da633bf7289f09c6a6175e7b586c01051267a66d08e1d7f6055f4af",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, TheHipsterCat, хипстер, кот, животные, animals, Hipster, cats, Vincent Whiskers, telegram",
+    "nsfw": false
+},
+"b9d869df0b3cf717b595f351a1ca8ad2": {
+    "key": "0fc2288fde7c9ed53c22c2335f8d1761568d04106a038fcf364b0b1c6d079501",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Vyacheslav Reyn, TheJoker, фильм, movie, telegram, Joker, telegram",
+    "nsfw": false
+},
+"f5909ad251531f5e0981e6c9f85b3e1a": {
+    "key": "b0fc383f973ad1e77455d97d9d7743eea3fd2fb5def86317004a4fec68c337fd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "TheJorge, монстр, monster, Jorge, telegram",
+    "nsfw": false
+},
+"b84cf688a81bbb5ceb0bf5fe81c320eb": {
+    "key": "d6ecfe80f424a0ef8a156742fbca551f7a0aebbed33c3f94f415b172e387c47f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Alina Nikolaeva, TheMatrixMovie, фильм, кино, film, cinema, movie, telegram team, The Matrix, telegram",
+    "nsfw": false
+},
+"ce09e52c3939608467dff8dcc4f53b91": {
+    "key": "a5f7d3a8d5eaa6fbe0d7c89c32e3799c916822f5c99fa2611da956820ef9b288",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Yulia iulaY, TheMuse, telegram, женщина, девушка, люди, муза, вдохновение, woman, girl, people, muse, inspiration, The Muse, telegram",
+    "nsfw": false
+},
+"1f9745b75162e132a1f5da380aae874d": {
+    "key": "fc3564d27e577f4160219ceff27c152680e53afdad1f12da48ddc0a300330d0d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, TheSailor, море, моряк, акула, sea, sailor, shark, Mr. Sailor, telegram",
+    "nsfw": false
+},
+"e9ade7da8be2b1fdbb50294cd45d2625": {
+    "key": "ae507cd6868f6c96760fbac587d3cede37a519f9b62a3cdda4960f496461bc38",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mary Virgin, TheSeacretLifeofPets, telegram, animals, cartoon, животные, мультик, The Secret Life of Pets, telegram",
+    "nsfw": false
+},
+"193a29772bc294917ee8157857a7edd9": {
+    "key": "b0b6d789318e8771fb2a6424fb73ec9f86afcc7ec879a20f00c0e4a36e764da3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, TheWallStreet, волк, деньги, животные, бизнес, успех, фильм, wolf, money, animals, business, success, film, The Wolf of Wall Street, telegram",
+    "nsfw": false
+},
+"a2dee2620c7c5710b1d45c6ef3408058": {
+    "key": "cd90e00407c611b2aa62491b25bc634cde08bd323cbee1eeccfa4bd567b6d063",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Tamara Gerasun, TheWitnessGirl, telegram, девушка, брюнетка, тату, свидетель, girl, brunette, tattoo, witness, любовь, смерть и роботы, The Witness Girl, telegram",
+    "nsfw": false
+},
+"c3cab3e27e80702991798a1b7bfef0d6": {
+    "key": "47cdb0683677bfcacc2dfa409b8274597e76e1952f8c9f66f5c4c08f96d999ab",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Анна Шумская, TheYoungPope, фильм, скриал, tv show, series, telegram, религия, The Young Pope, telegram",
+    "nsfw": false
+},
+"f4ddbccce7dd4748c0eddfd267d7f7cf": {
+    "key": "4749d55b742e16f8531c76d312d44496ce35154bce37c682bff3731a8732831e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александра Монастыршина, The_Meow, котик, кот, котенок, животные, animls, cat, The Meow, telegram",
+    "nsfw": false
+},
+"1b7188c66fd83e5d70cf93430c855e30": {
+    "key": "c91cd21b115618578d17e46f9a93fd6df13cc035d8f110870a654327bea59691",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Thecatjazz, животные, коты, Animals, cats, кошка, кот, The cat Jazz, telegram",
+    "nsfw": false
+},
+"2618c0f9f479391b163f0e4b524f0e3a": {
+    "key": "7cce84058fb0cc0e8c30722bbda7015a08c2e857faeb497527ae9e56be3d048b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ThisCat, коты, кошки, животные, animals, cats, Katie Cat, telegram",
+    "nsfw": false
+},
+"8968d40073e6313bee1476ace1a76963": {
+    "key": "405cabe5a58e725b770c043f44471361cbabb44d53c1eabc6ab3f0398b0a3289",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, This_is_Sparta, спарта, мем, memes, sparta, This is Sparta!, telegram",
+    "nsfw": false
+},
+"f4118f7d629e41af2fe307dd2e062516": {
+    "key": "6279cbf7021b9667317aeae400516bca1bf95c1d6765701dfceae17588ce5d18",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Serbun, TimothyBurton, фильмы, люди, режиссер, movies, people, director, telegram team, Tim Burton, telegram",
+    "nsfw": false
+},
+"e1e81e585e2dd27f054d54cd73e6fef6": {
+    "key": "a80e38cc526ea944773c9a890f0da13f33ce5fc5436b24da19bc94c75be08c6f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Anna Kostiv, TitanicLoveStory, telegram, любовь, титаник, фильм, отношения, романтика, 14 февраля, день святого валентина, love, titanic, movie, relationship, romance, february 14, valentine's day, Titanic, telegram",
+    "nsfw": false
+},
+"9c7a51cd17aa2f59ee477ffc37afe5be": {
+    "key": "7ff41e9943427a22657e65b0b2e8dd4cd59f410766acf8343130056cfeb153fb",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "AnzhelikaJoy, ToddBear, telegram, бизнес, медведь, животные, деньги, богатство, business, bear, animals, money, wealth, Todd Bear, telegram",
+    "nsfw": false
+},
+"9134b27bb89daba3f28418b23d6af9d5": {
+    "key": "ca059b28addd675eed807c121dc77a380ac29c872e27317e1bfbc3795dfe25b2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Dima E, TomJerryFun, telegram team, мультик, для детей, кот, мышь, животные, cartoon, for children, cat, mouse, animals, forkids, Tom and Jerry, telegram",
+    "nsfw": false
+},
+"13adaa2422c0696bc2205abed9918504": {
+    "key": "7d6781abbe2622ad71a0c2a501c83e56d503197b92fcddf531e59b0996f72d9e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "TomaStic, cat, animals, антропоморфизм, кот, животные, Tomas, telegram",
+    "nsfw": false
+},
+"1ee7918926069004bb2ab2d193a0ac3c": {
+    "key": "dead468140681a8bbd959de0551f2015bc76543ae5f31c79c0d5d38ddc2b3c33",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, TopDog, животные, animals, костюм, офис, победитель, winner, costume, Top Dog, telegram",
+    "nsfw": false
+},
+"e042bbea92d8a1139295aaaea8ff5645": {
+    "key": "a225b860746cd7def5d3f95de1749b1525e9c01145da9b1e3f39058fa83ebc4c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Google ALLO, Torobijat, овощи, еда, редис, отношения, любовь, семья, vegetables, food, radish, relationship, love, family, allo, Torobijat, telegram",
+    "nsfw": false
+},
+"9b1c856060d7088f17f204a80d782263": {
+    "key": "1edf76a7d1a468466cecebb48d3d83b9ad1683420d461812a3854c1e2458993a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Darya Ogneva, Totoro, тоторо, мультик, cartoon, totoro, telegram team, Totoro, telegram",
+    "nsfw": false
+},
+"a15812368b624d8536f68f3d938bb30d": {
+    "key": "0175f5db1718af02aac16a4a1211304a443d88f4bdb0959961801306720bc544",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ulyana Tkachenko, ToyStory, мультик, для детей, игрушки, toys, cartoon, forkids, telegram, Toy Story, telegram",
+    "nsfw": false
+},
+"10c39eb22809f940ddc3a779e2c1d5d3": {
+    "key": "da6837a532e289ae77162ae2e2828a4b3e4adf268a29768dec84b5453fba98a1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Viktoria Moloko, TravelingSalesman, seller, продавец, парень, мужчина, salesman, telegram, James McTout, telegram",
+    "nsfw": false
+},
+"b39556c8877af6d483e535aee29e89f3": {
+    "key": "dbf944616fda45b2d59631a82213a93a40fabbac99a94d767d150a9a7f74364d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, TropicalHolidays, новый год, зима, отпуск, отдых, new year, winter, vacation, Tropical Holidays, telegram",
+    "nsfw": false
+},
+"999127083b93400085f27e2ddfe57990": {
+    "key": "0e033c9c71b440a6b1edfc37ac597d924654501e0d6e9a39f5d7487b98ede0bd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "TrueGamer, игры, люди, games, people, True Gamer, telegram",
+    "nsfw": false
+},
+"ef702b19d5b3cfb27785deda673780d9": {
+    "key": "92cf1d97eb313087a9186ab7b07c1f83826c85d3d326cfbf2c34071eae475166",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Владимир Сарикян, TrueVaper, вейп, пар, борода, мужик, вейперы, Vaper, beard, vape, True Vaper, telegram",
+    "nsfw": false
+},
+"ea46ea619ec96e06e810023af317022c": {
+    "key": "4a84d3046eafb93f0f0589ba57d855a9873c4dcff4c663d511a84850951f0e94",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Лариса Илларионова, Truedetective1, фильм, сериал, сезон 1, series, True Detective, telegram",
+    "nsfw": false
+},
+"9f76f596090e6dfe6fe9ae775021f1a7": {
+    "key": "8cb843ad2c1780ce5e282b884f2fec36f3998098b6fa41f1ca9e1446c4c2638f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Andrey Pryvalov, TunaTheDog, собака, животные, dog, animals, telegram team, Tuna the Dog, telegram",
+    "nsfw": false
+},
+"1b858dc00fedd6db9d019137c32ed98f": {
+    "key": "0ae38748fa35749bf5e0ebffce5d67327b5b47370ab3a8ff4175d9a76728f6aa",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Facebook, Tuziki, заяц, животные, hare, animals, Tuziki, telegram",
+    "nsfw": false
+},
+"b0458550ab38e27058cc92237d84ba15": {
+    "key": "0d7586416225bd34ecfdf3f179e51c663b5dcb6f318ba1b2071f38dac7a96bf2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Tvorozhok, animals, животные, кошка, котик, котенок, kitty, cat, конкурс2016, Cavy, telegram",
+    "nsfw": false
+},
+"4b32ed1ba8913de2020e8dd42f3bcfdf": {
+    "key": "63a9fd9630c18ea20bde94c3374f4a3da20bc878a664819655c6372aa01f8564",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, USAPresident, америка, президент, политика, сша, трамп, America, president, politics, united states, tramp, Mr. Trump, telegram",
+    "nsfw": false
+},
+"bb1d85bab880b549fcfcb0707d6bd957": {
+    "key": "67e95c502fdfe3687681265f669cf8661613fa2da75e07236406a15996d59156",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "UglyKnights, рацарь, доспехи, средневековье, armor, the middle ages, Ugly Knights, telegram",
+    "nsfw": false
+},
+"8fb6922a8318f1418d5564e36b8fb50a": {
+    "key": "d9d41fbd1090b5490ca157f84d7d6b52e868e52f6d759a6eef6049b3cf91e85f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "UltimateMachikoPack1, животные, кролик, мачико, заяц, hare, animals, rabbit, machico, Ultimate Machiko Rabbit Pack #1, telegram",
+    "nsfw": false
+},
+"607b3ab4469181bc98d26056b994bfe9": {
+    "key": "eb9ab2286a8fa189a3b2c0b5293802a67203a00c4e9cd63f94ab7d90545eed9e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "UltimateMachikoPack2, заяц, животные, кролик, мачико, hare, animals, rabbit, machico, Ultimate Machiko Rabbit Pack #2, telegram",
+    "nsfw": false
+},
+"cf85c016c3eca63bb9948bd8f228c0e3": {
+    "key": "8cb84114897230bd3ec3dd3a8a11b28431ae8f0243afe71fb56d46be5bd01fc2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Stasik, Ultra_Violence, музыка, группа, метал, music, telehram, Ultra Violence, telegram",
+    "nsfw": false
+},
+"c1464c5bf309c659150ccfaf7bf80dfc": {
+    "key": "3898ac4e5eb5c1cfdeb1922508e358f5f673265844441aa6da1dd3354c87af05",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Unicellularstickers, клетки, биология, наука, cells, biology, science, Unicellular stickers, telegram",
+    "nsfw": false
+},
+"acf3d6a73a24d161a49b5bfe36bb461f": {
+    "key": "4a09a70e9d0763f0a0d8fbd39afd57c0b8c5d69c839f6341fca4132c20ce7cb2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Анастасия Сержантова, UnicornStella, для детей, мультик, единорог, розовый, cartoon, for children, for kids, pink, конкурс2016, Stella the Unicorn, telegram",
+    "nsfw": false
+},
+"a247e94e38480a0dfea79b7e783560fa": {
+    "key": "f33f40098f0ee42a21b32920c09c373322ce3856561c6983692354df4e761138",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "UnicornoCat, кот, животные, cat, animals, ЕдинорогоКот, telegram",
+    "nsfw": false
+},
+"f3b0da30b507cbf7217b3bced406ea54": {
+    "key": "720a8773268858acc67244eb348e841e368341f91dfd711cf0138cb0d3bde3a7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Aleхander Filinkov, Unicot_AFilinkov, кот, единорог, животные, unicorn, cat, animals, Unicot, telegram",
+    "nsfw": false
+},
+"c05af805505759d5fc9539219f229951": {
+    "key": "a0c8b84b419cc363b284adfd3c4ff1cc2ecbdf832d4b1ab749628929767bf6f5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, UnluckyButVeryKindPig, хрюня, свинья, неудача, грусть, тлен, животные, свин, Неудачливый, но очень Добрый Хрюня, telegram",
+    "nsfw": false
+},
+"99fa1d9184a50d0e930457f8f1ce3adb": {
+    "key": "94ef5b9723a99444f5dd39da692afc3ae1503b672a5c6e3c8f08cf648436cc8d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Unofficial, дуров, люди, игра престолов, telegram, people, game of thrones, durov, маска, пушкин, Unofficial Telegram Stickers, telegram",
+    "nsfw": false
+},
+"27ecb8a4af542e7ceb5ba3532df5d03e": {
+    "key": "eac09eb9df8dd1a9369e6ea1ad278b3fd66296287fb829be452e067ab64bfc62",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, Uprt_Animals_part1, животные, animals, Uprt    Animals by @stickerus, telegram",
+    "nsfw": false
+},
+"5807f9a8b4a073d07d64dafe948a3f1b": {
+    "key": "8f3edaf4aef7ce29b291dd93f31a9a4268427814c14eaa37e6cbfe73b91e4929",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Utiki, дракон, животные, dragon, animals, Utiki, telegram",
+    "nsfw": false
+},
+"6de3ab8700220905936db5e1f0cd3746": {
+    "key": "7a376f9d432dd812bb4e82c77ec17360046feb0cd576349fc25d4885a8c4fdec",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Elena Savchenko, VKsmilies, вконтакте, смайлы, эмоции, smiles, smilies, telegram",
+    "nsfw": false
+},
+"8500b8dc2e737abb3bc135c4eddefdae": {
+    "key": "d4da3628e7ae66879114a787cc90c756c41c21b9da98b78d5ff32e37ed8300aa",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "alinamalutina, Valentines_Chat, любовь, отношения, романтика, фразы, 14 февраля, день святого валентика, love, relationships, romance, phrases, february 14, valentine's day, Валентиновские Фразы, telegram",
+    "nsfw": false
+},
+"1aa955661643e9567e6de43a7f67f54b": {
+    "key": "8c7d985ee4365ea88c51cf382f472b252d557532c99fb4afbda2964feba74030",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, VaperGirl, вейперы, пар, люди, девочка, people, Vape, Vaper Girl, telegram",
+    "nsfw": false
+},
+"b437468f1c4a94ce542848ce9535677b": {
+    "key": "bc0e577b1f90321e611ca179f6531ba0a1376e15c86fc32a804134b597f88c3c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Vasya_Piton, doge, доге, вася питон, собака, животные, animals, dogs, Vasya_Piton, telegram",
+    "nsfw": false
+},
+"90be8a55864ae33785b09116c7793b62": {
+    "key": "e38f98b578f3c8a07a8dfeac6203e6ee9e349989383fdf9cfc56bd7b014c8384",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, VaultBoySet, игры, фоллаут, games, Fallout Vault Boy, telegram",
+    "nsfw": false
+},
+"8cc299c2ef6650495d239e174bb8a268": {
+    "key": "67b6e549fe26ced1fbd12b4d3ded2542d315b97ff64449df1fb011ce2f8bce03",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Рута Михеева, Velociraptor, динозавр, животные, dinosaur, animals, telegramteam, Velociraptor, telegram",
+    "nsfw": false
+},
+"43ed8518537a255459ca5941b216552e": {
+    "key": "9b81ca3ffe6134c42cf16f2b3d18528a1411b0fa41af2ef00befad29333aa444",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Sergey, VenetianGondolier, венеция, люди, гондольер, venice, people, gondolier, telegram, Bernardo Gondolier, telegram",
+    "nsfw": false
+},
+"ae97ea5ea215dbae919f184edfee145c": {
+    "key": "5f9282b2f4971be10cc31f35e7940d0d3db141c589a45d6374c3886ed79d41be",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, VeryBadGirl, люди, девочка, girls, people, Bad Girl, telegram",
+    "nsfw": false
+},
+"427c979419c62a1bf4305006a9fc359b": {
+    "key": "02e7ad3996af0ebf6377fb6d7bf575e9aa512462b1cd5c836ed916d0649d46d6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Serbun, VeryNiceBorat, люди, персонаж, казахстан, мужчина, people, character, kazakhstan, man, telegram, Borat Sagdiyev, telegram",
+    "nsfw": false
+},
+"5f3867f76ae252913d691497084c0842": {
+    "key": "326e5c26d8307469bac09c0f63483d6be03181e5e28e6ebf1e43176d546791c4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Veseliy_Kamen, stone, камень, эмоции, Веселый камень, telegram",
+    "nsfw": false
+},
+"27b1a217731f54a178f49ed031c2c98e": {
+    "key": "97819933e7dde61587c4b55e99a2f79fe765126771e163d51120dc2c0105041f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, VikingAge, викинг, средневековье, рога, Viking, Middle Ages, Horns, Viking, telegram",
+    "nsfw": false
+},
+"1e8ba0a37503dbc8e6e8016e1161604f": {
+    "key": "5d6b52e538c4eed614950db9e6c75f950e858daa56497e5e8ad7eac3a02a1cf9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Tamara Gerasun, VisserYolandi, люди, певица, музыка, people, singer, music, telegram, antwoord, ninja, chappy, чаппи, Yolandi, telegram",
+    "nsfw": false
+},
+"1a8a0e38cfd3bab55e816ee61b5f046b": {
+    "key": "2185b9f682b40c9470b787e9d616a51920f56ccedc2f04187e08f70fa47471c0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, Vlad_Len, владимир ильич, ссср, россия, правители, политика, Vladimir Ilyich, USSR, russia, rulers, politics, Lenin, telegram",
+    "nsfw": false
+},
+"55dcd11fa4a64ae37825bfc85abef7b5": {
+    "key": "90f207324a071053dffd360d502288418dd75a76112874ae5d2d2c4c4ffddc00",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Vlad Leonov, VoodooDollChumbo, кукла, вуду, voodoo, dool, telegram team, Voodoo Doll Chumbo, telegram",
+    "nsfw": false
+},
+"d6ca992d52f32e57a4f67ead7ce80158": {
+    "key": "dcfa5320922757360d2cf8872ad9c9275529905e34f91a1f10cfbe122c4d18fe",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "WainKots, коты, животные, animals, cats, Луис Уильям Уэйн, Louis William Wain, художник, artist, art, арт, WainKots, telegram",
+    "nsfw": false
+},
+"f8b86e824f5df2d540274a6138485019": {
+    "key": "c56f718954b4dda67a530145ecd6c45259f1c4f708db1382318f1af1b66cd68c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Анна Шумская, Walter_White, telegram team, series, movie, breaking bad, во все тяжкие, сериал, фильм, Breaking Bad, telegram",
+    "nsfw": false
+},
+"29a548462328afc4ef71110f111ce2f8": {
+    "key": "f3cedc1e542d02d052fd7d7d8d4b71a6aa9cd8e8fe5f632b1c7aa5ea4c8bf454",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Revenge Meow, WarriorQueen, фильм, девушка, женщина, film, girl, woman, movie, telegram team, Warrior Queen, telegram",
+    "nsfw": false
+},
+"56be18ecce5578cf130cdbd6fcaaa4c3": {
+    "key": "12f3d9d017d282895a020d6a6e188e9d9594408c98dc0d870b072f08ddba3a19",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, WaterPug, животные, собака, русалка, рыба, fish, dog, animals, Water Pug, telegram",
+    "nsfw": false
+},
+"bc1ec24961161b148e9a3141bf186e6b": {
+    "key": "01e483a27776cb3e914edbbac66d7ec4c6fbe702919c0ccdf243ea6a418a4160",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Олег Горбачёв, Weddinggirl, свадьба, любовь, отношения, невеста, жених, 14 февраля, день всех влюбленных, день святого валентина, Wedding, love, relationship, bride, groom, February 14, Valentine's Day, St. Valentine's Day, Wedding, telegram",
+    "nsfw": false
+},
+"cd1ce42c8011549b9335b4cad365f9d8": {
+    "key": "ad84093784a8e1102190b4ebb061fed0c73964e7ec92bb4f0be753b3b9097a42",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Лариса Илларионова, WelcomeToRiverdale, сериал, series, Welcome to Riverdale, telegram",
+    "nsfw": false
+},
+"febafae88990a0a8db65f57f7b2318e7": {
+    "key": "ab329d95df14a804281a384d202e9c947b73caa9c4a72eb210471c61a02203e7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "WhatsApp, WhatsApp_Cups, whatsapp, вотсапп, посуда, чашки, WhatsApp Cups, telegram",
+    "nsfw": false
+},
+"86951323a049f4e936cbdd149dfedfef": {
+    "key": "16a49756d7528be81b2c5ed0d896f39bd35a44a75cac553bd87a3aa16f9cee0f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Антон Андреев, WhiteHenDarkSoul, chicken, hen, bird, animals, животные, курица, птицы, Meme Chick, telegram",
+    "nsfw": false
+},
+"ff76a705ddee38ca1dd8112d6a0acb90": {
+    "key": "2ad17da8f8f601dd6da16ad0fba3aeceda1bdddfa2fc204f3cc96b34ba514514",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Anna Kostiv, Whoniverse, фильм, сериал, фантастика, film, series, science fiction, telegram team, Doctor Who, telegram",
+    "nsfw": false
+},
+"741101938bc0b6b234c3377ff401d978": {
+    "key": "300fcec166fa976ba7b5aed90911f1c529f3cc7457f31b3ee84d8bab9dcea21d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Yulia iulaY, WildWoman, telegram team, женщина, люди, эротика, страсть, блондинка, woman, people, eroticism, passion, blonde, Wild Woman, telegram",
+    "nsfw": false
+},
+"a4d0869106f67799e09a89362479b393": {
+    "key": "00d5790ab2628421a00b4ac4cb4504e2f161c60b7de81f59f155c1b268303245",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Yulia iulaY, WilliamShakespeare, telegram, любовь, отношения, романтика, 14 февраля, день святого валентина, книги, шекспир, литература, love, relationships, romance, february 14, valentine's day, books, shakespeare, literature, Shakespeare, telegram",
+    "nsfw": false
+},
+"4923abd05727e01e6b7a48fb726d0cde": {
+    "key": "32f2bbd3b9249e7f3da7da60e93ce871da226392da91b411a2e04b495d8bb519",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Alexander Sorochinsky, Winter_Is_Coming, игра престолов, tv, сериал, HBO, tyrion, snow, game of thrones, сноу, тирион, Winter Is Coming, telegram",
+    "nsfw": false
+},
+"a6b97e4981a9a773269feba09b2d73e9": {
+    "key": "26478aa0f2e3a644012ff121ef74f33659a9bc314e6fd476ba70baf18199649c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, WitchMorgana, Колдунья, Witch, helloween, хэллоуин, ужасы, horror, Morgana the Witch, telegram",
+    "nsfw": false
+},
+"30ea120f9e47b0223684e9ccb5371822": {
+    "key": "a042f203c39a7c63b9ab57d8cfa10c53ceb7b3215e91ffc7781caa8b788f387f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Krasivon Art, WithTheBeatles, музыка, люди, группа, music, people, band, telegram, The Beatles, telegram",
+    "nsfw": false
+},
+"087032d5e1d3169fe808cd20521ca3c8": {
+    "key": "d708c2906a01d075741857e574a4871303d507b2c5c68441b0f1c3696e5baa5b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Snowy Jellyfish, WonderWomanDC, женщины, фильм, супергерои, women, film, superheroes, telegram, Wonder Woman, telegram",
+    "nsfw": false
+},
+"d4ac65634c4eafb07ae15695726f1c27": {
+    "key": "b1258a5c67c259e682ab36df8bdfaf65b5ebcd065e820492e3b26e62c563b9e7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, WoodNymph, girls, Nymph, Нимфа, Wood, девушка, фея, Wood Nymph, telegram",
+    "nsfw": false
+},
+"c62426bb6380ffc4fdded9ad0b5c699b": {
+    "key": "1f3b84f50f2bd3f776a4a5aa11a17e7cb14436a09d120239a0fc21b7321d5007",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "WrongNumber, игра, отель майами, жестокость, компьютер, computer, game, gaming, cruelty, HotlineMiami, telegram",
+    "nsfw": false
+},
+"c90e6efbbff23bf1701fad8a11fb2bdd": {
+    "key": "8bcdc8b8e45c871b31c899b4abfdbf3254f8c2c5fa590ef923de2b3d1d89ad01",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "YangoTiger, тигр, животные, animals, tiger, Yango The Baby Tiger @TgSticker, telegram",
+    "nsfw": false
+},
+"5c95d6630ade62f829e3e0b22f8dd67b": {
+    "key": "ccd73e6106e29ce15227a86853824d60e8fe10c3ce850bac7bbbb4e0b1d9a937",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ольга Янго, Yangochunes, animals, pig, newyear, новыйгод, животные, свинья, Чуня, telegram",
+    "nsfw": false
+},
+"20dddccf57bf1db513007314f9057f87": {
+    "key": "fdea34387a71bdbcc150b3aaeab531821b3734e94c18034980470d05c288a025",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "NBstickeria, Yawn_NBstickeria, сон, усталость, зёв, зевать, будни, yawn, tired, sleep, Зевота @NBstickeria, telegram",
+    "nsfw": false
+},
+"04afe92c67469b4c6572c39aa221e25a": {
+    "key": "19bdf2691b0cbf3aeb95e987f49e030e91eaea73917f76ea68e4a47e75cf9ea2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Artem Vasiliev, YellowBoys, миньоны, мультик, для детей, cartoon, for kids, minion, Миньоны, telegram",
+    "nsfw": false
+},
+"8c89a36f967c1da89d3e68d58c46a685": {
+    "key": "502a8af4caf7960781ffc02ce462a40124689c947c87f19936b9de585cf89e4b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "YouMasks, дарт вейдер, война миров, цепь, маска гая фокса, очки, darth vader, war of the Worlds, chain, Guy Fawkes mask, spectacles, glasses, YouMasks, telegram",
+    "nsfw": false
+},
+"d0915b31b83c168dda0197884c220cd3": {
+    "key": "072351a38b3b367154fb4246b0516207e5f65c34034ed443c3bb813966f125fb",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "@StickersMM, YoungAndCoolCoupleMM, любовь, отношения, сердце, пара, влюбленные, молодожены, 14 февраля, день всех влюбленных, день святого валентина, Love, relationship, heart, couple, lovers, newlyweds, February 14, Valentine's Day, St. Valentine's Day, Young & Cool Couple, telegram",
+    "nsfw": false
+},
+"c8eb765cab5c17229e3cba30f7800798": {
+    "key": "4c9c8d7e8cb7d22f58305558e75cc9c7685ebb733fa89331f638ce7e4424c79b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Maxhasky, YourALF, telegram, alf, movie, series, альф, фильм, сериал, ALF, telegram",
+    "nsfw": false
+},
+"e89a5f36479a28517b7705e493773056": {
+    "key": "8f9afc32a9c360a2ab28cecaea8bcae2a3aa876bdc01ea05e16ce330cbced49b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, ZForZombie, зомби, люди, мертвецы, dead, Zombie, people, Z For Zombie, telegram",
+    "nsfw": false
+},
+"a815b32454a387bed15522a59e64dead": {
+    "key": "25255f84423bd537d1d71afa0c71924234560263b42d7b1453e9e6c9834dd10b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ирина Терюха, ZaiMorkovkin, кролик, животные, заяц, animals, rabbit, Zai Morkovkin, telegram",
+    "nsfw": false
+},
+"4d1ae3a56fbb8a3fd585a33ca9bf3f25": {
+    "key": "2950fe026183aa4ecd3c534dfebc31269379eef599c51249a8d2da4ab6c690d0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ева Гибнер, Zhirobarsik, кот, животные, надписи, Zhirobarsik, telegram",
+    "nsfw": false
+},
+"a68544f6190fcff403d359b64b36c2e9": {
+    "key": "d9742c8d0ab8380812fdb5c63ea1837a0b7b2be5c90b43f49e783dde558f4509",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Telegram Team, ZippyUndeadUnicorn, животные, animals, unicorn zippi, смерть, death, Undead Unicorn, telegram",
+    "nsfw": false
+},
+"cfba9f776ab92956b39f95470a8d60c9": {
+    "key": "edcf457ff562361f9bedd6d364ff79cc5bec7fc36ba5afc6f3e49b4b1df1a439",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "NBstickeria, ZombieUnicorn_NBstickeria, единорог, животные, зомби, хеллоуин, unicorn, animals, zombies, halloween, Unicorn Zombie @NBstickeria, telegram",
+    "nsfw": false
+},
+"338efc35e384bd5a6d31199c8b5d0a90": {
+    "key": "a43be956ba7baa2dd644dc9a6fc1748aa5c42c3ff1adfbe39a96cf3452414058",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ZootopiaJudy, zootopia, зверополис, мультик, кролик, cartoon, for kids, для детей, ZootopiaJudy, telegram",
+    "nsfw": false
+},
+"54b60f7ac9e30263fff5bbc7261fcd1b": {
+    "key": "55097072913b1585348a33f45276b2345540e173ef7badba1982d1e8655d540f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александра Власова, a_genez, art, phrases, фразы, слова, antropogenez, telegram",
+    "nsfw": false
+},
+"e6a6801558d214fd641ca874758eb410": {
+    "key": "d25daaccad8b3074e697b44141aa89a5910221d1d29ae06757260070e589cf1f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "afasoft4, мультик, cartoon, для детей, children, kids, собаки, dogs, животные, animals, afasoft4, telegram",
+    "nsfw": false
+},
+"3de494a92c5cdc4b7448635df94163ef": {
+    "key": "7598cad7a8e8b101fa4224a4bf349e897d672a0c43691d7e89e4e0f665cb9a35",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "valeria.vetrova, ahimsa_items, еда, овощи, здоровье, веган, Ahimsa Items, telegram",
+    "nsfw": false
+},
+"7d0352fb286e9bd48c59b71c187df191": {
+    "key": "be906305a9eab40e47f37f540d1e917130e1a9bab3d047c66ae1b338d4bb59da",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Алексей Шурмин, ananas_vk, лето, еда, ананас, фрукты, вконтакте, отдых, жара, Кислый :: @stickroom, telegram",
+    "nsfw": false
+},
+"31c0317d28eaadd08559feaf7734422d": {
+    "key": "c3104bc31cd54a4f29eba2cb60db316c2137473b50b3311721b8ac4e564df6a8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Florian Weigelt, andMoreMe, монстрики, чудики, monstors, милота, cute, andMore, telegram",
+    "nsfw": false
+},
+"b9361b3652fb260ed11bdc8235f6d197": {
+    "key": "949dcf8d110e5fbe1981704a63e19225a59ebe5b9a2f6a8bc98b6aec29c33bd0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "angel_marie, вконтакте, люди, people, Angel Marie, telegram",
+    "nsfw": false
+},
+"2ff2f90aa4f35e5c1a46967ae8be00b9": {
+    "key": "f96f26775de0ad535ba7faccec350c7e8735cc5ab2b3c07e35de4468de346534",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Kate Kros, aqula, shark, акула, животные, море, AQULA, telegram",
+    "nsfw": false
+},
+"e182d7927857b34a2384632b5a9ed5d7": {
+    "key": "534ab19efb791c74317583c3c66d8a7107cb1eb80b56fbb0e4f2d34fff9fa67e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valery Matyukhin, arcty_vk, вконтакте, животные, полярная лиса, animals, polar fox, Arcty, telegram",
+    "nsfw": false
+},
+"7a4bb5a85b0325e04e7b42c987187cce": {
+    "key": "c65b552acfe07ded6895b04c9fd37ea0ac0475708e8d4b935cd859b6574d148f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Филинков, arisha_vk, вконтакте, девочка, ариша, арина, люди, people, girls, Arisha, telegram",
+    "nsfw": false
+},
+"40342670fb48bf647f5beac7ccd507ca": {
+    "key": "55e3722cfe4563c34257c2456f1ebf45e8596026b3138237a3be9e12cdf5a6f1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Milena Gašparin, artistgirlstickers, девушка, художник, girls, artist, Artist girl, telegram",
+    "nsfw": false
+},
+"7023c2e5a0e5275f4da15171baf0a95e": {
+    "key": "c1e1c712f28befdd48cb48f11c9354d3ea43d69de05edf2bfdd3ba609172da03",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Yanochka Bash, bagi_yana_b, дракон, dragon, animals, животные, Баги (inst. yana.b_art_), telegram",
+    "nsfw": false
+},
+"6207193acb88e9857e6b660674d7ef3b": {
+    "key": "6981bb339f8d18e9292bf25968f821b167f75ad275b5e7e227e7cfeda2365e26",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Evgeny Bam, bamscattodog, кот, животные, арт, art, cat, animals, П, telegram",
+    "nsfw": false
+},
+"8448a0651c23bdc366df7966b71ca928": {
+    "key": "24df95b1d85be86d4b951ea94e5242267e2413d7b7f548eef6d1fadbb18f0d90",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "barista_en, кофе, монстр, monster, cafe, BaristaStickers_en, telegram",
+    "nsfw": false
+},
+"5201e23e4576270d4138cca19cfef206": {
+    "key": "73d7a56b8ecfe8652a7c152a2f6dee786fe1964a52b716de8694081c2e0a42c6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "barsi, cat, animals, кот, животные, Барси, telegram",
+    "nsfw": false
+},
+"bd77fb59b67e189e9ca61ec8e973c90c": {
+    "key": "32634448d2e90e8ec1587a7a7a4052945c1018e61ca8704b67822ff09f4293ca",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Татьяна Заболотских, bebeshka, овца, sheep, goat, козел, животное, Bebeshka, telegram",
+    "nsfw": false
+},
+"e6f0f2a46d160285fb50259e17ac1b5f": {
+    "key": "bcfe1e7c62ef4e4a613bdb1e929e7a3ad81fd6bef27ffddc4d0e3bb6e81384a7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "bigbosslee, люди, человек, расследование, детектив, шпион, people, person, investigation, detective, spy, BOSSLEE, telegram",
+    "nsfw": false
+},
+"66d06622a1b5453cf17a651347816253": {
+    "key": "9e509c65ae81ccbc145f14ab87a9b2967005ee94afb0ef9c9dc647a9be05bac3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Elena Savchenko, biglove, вконтакте, любовь, влюбленные, животные, день святого валентина, сердце, обнимашки, мило, lovers, love, animals, sweet, biglove, 14 февраля, Дела любовные, telegram",
+    "nsfw": false
+},
+"8449f432aed1056c863e1378f14e80fb": {
+    "key": "5b3ae7d8249ccbb85010e59533b388a4ec7d6d519316e5d3bbbd0a780bcf59e7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mikhail Golub, bin_vk, вконтакте, лемур, животные, animals, cute, милота, Bin :: @mosticks, telegram",
+    "nsfw": false
+},
+"82b455a6e60aba6aeea14f49a945ab6a": {
+    "key": "3d83f163ef27f8730dc470f26061e73e52879d4ab9c8854bb78c741c166338c7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "blacksesame19_eat, еда, рисунок, арт, пошлиесть, жрать, картинки, eat, food, art, Blacksesame19-Eating, telegram",
+    "nsfw": false
+},
+"231f862f524c40d8709558f8b23b790f": {
+    "key": "d3810ef3208d2c003fbe3f7583f7870b8ab95d08ecc7d187303f13ec8b8132a6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "blobby_stickers, капля, шарик, чудик, блобби, Blobby, Blob, Blobby, telegram",
+    "nsfw": false
+},
+"2b75fc1d8346e802a5fbf46f9b46c8f6": {
+    "key": "e84bebb7217413bd7144115e1a5936c70afe36dd8aba3adf7945b6c850da87e8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "blobbyyyy, абстракция, розовый монстрик, Abstraction, pink, monster, кетнипс, Blobby, telegram",
+    "nsfw": false
+},
+"39d894415f6df98312a0c4d96ef4c135": {
+    "key": "38cd8b5558e5d5fd85016bca3f4eb7e1ed80c7413097eaf258a250fcd1f7dd32",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Юлия Баляева2, blueemotions, люди, эмоции, emotions, people, Blue emotions, telegram",
+    "nsfw": false
+},
+"6474e8f31dd47fc48f389ebfaeb3fc08": {
+    "key": "271f6c755bd4dadc21d2d9530712bafb67a81659dd74cdfee4bfca462c6036d9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "boringmonster, монстр, чб, чернобелый монстр, monster, BoringMonster, telegram",
+    "nsfw": false
+},
+"e7995dd884484991cbed200b7682ca83": {
+    "key": "a27098f4c27348b25b0104e7997dd6a64e1cec9bb7320f37a178210dc408df1a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Katerina Bulatova, broccoli_umzarazum, broccoli, food, еда, vegetable, овощи, Малышка Брокколи, telegram",
+    "nsfw": false
+},
+"43ef5a3db34b95644fc1bd5492b52c25": {
+    "key": "0c1659c856d294255b38dcb70e9c6b88cadb3781ea840b169c8495dc98ee088c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "brokencats2, cats, коты, кот, упоротые, Broken Cats 2, telegram",
+    "nsfw": false
+},
+"97a3571a8e6f5225000d48e80010d45f": {
+    "key": "541f0f14fcfdee0ec9599a21d385ee85f4168856741928f7928de9fa74da0f94",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Nastya Driga, brownie_vk, bear, Shunya, вконтакте, animals, животные, медведь, любовь, love, 14 февраля, день святого валентина, дружба, friendsheep, Valentine's Day, Brownie (@tstickers), telegram",
+    "nsfw": false
+},
+"8f765069630bd375cd876aef3e6cd91f": {
+    "key": "fa8fc8ff03bf19db508270ff8f609829a6ff1058ce12c424377b945c47d427f4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Serj Martynenko, buddhacrypt, биткоин, криптовалюта, будда, деньги, crypto, bitcoin, Buddha Crypt !, telegram",
+    "nsfw": false
+},
+"0e549afc5aaab71fc4d1b74f0fd6899a": {
+    "key": "df5a5149ae85502a5f7b4d394e0494a77ff19f3dc08a1a2331a33f848fbdce17",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Анжелика Кирюхина, bunny_rosy, животные, заяц, зайчик бу, кролик, animals, bunny boo, Bunny Rosy, telegram",
+    "nsfw": false
+},
+"b1915284f6376227c89d9c313dc0eac5": {
+    "key": "4f96bec276d15f3954c98b51df919434e1ca2ecda3946c45ab9e03561d96486c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Clementine, buttman11, попа, funny, butt, buttman, telegram",
+    "nsfw": false
+},
+"fa6c5e6df2de9cb5eef3f6a19979c93f": {
+    "key": "12bc49244ba1fc54b569b58fba53a0b764b998fae82a7a51fb34f8b85fdb9a2c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "VKontakte, cartoon_vk, cartoons, мультики, вконтакте, Cartoon Network :: @stickroom, telegram",
+    "nsfw": false
+},
+"9d89d051f4b92a03aaa638f1050adb5e": {
+    "key": "d7c162f9cd8937bb2aa7f92cfb30843b8d81d7f351c35a799dea8ed70f97c214",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Lerik Smith, cat_teftel, кот, животные, cat, animals, cat Teftel, telegram",
+    "nsfw": false
+},
+"cadf728df3b428d9de2ba02f735610a8": {
+    "key": "2e0312c7d2f3439b6dbf6d1b0c0f6aa1d94ec5d32d2fedccf2f877e3d865ccf1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, catcorn, cat, unicorn, animals, животные, единорог, кот, ✨ Котики-единороги @lennysticker, telegram",
+    "nsfw": false
+},
+"2967ed9bc54a110990a2e275920e2abb": {
+    "key": "01cd264788f229be7cfb3bee5b7f6152903cbae8558fbc57302c99087fb3e326",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "catpower, животные, animals, кошки, cats, коты, кот, киса, котенок, catpower, telegram",
+    "nsfw": false
+},
+"067d5a5068db0f1a367ebe43fc6388fd": {
+    "key": "8b5024a20fec309de273a9199a757723a4a924ff7a99a8fd24f345f29fb432c6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "alinamalutina, cats_and_love, love, cats, animals, february 14, valentine's day, 14 февраля, день святого валентина, любовь, коты, Влюбленные Котики, telegram",
+    "nsfw": false
+},
+"e93045450758ee8dad17c7311ccb4812": {
+    "key": "8342ad48f1db8dd180efafc43d1c14a2cd71a4781d8dae5f795eec76429ea1d8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "catstickersmm, коты, кошки, cats, animals, животные, Cat Stickers, telegram",
+    "nsfw": false
+},
+"e68e46e741d2d9cada230cb06985d539": {
+    "key": "548911a013765a643edbfb18a2245f44f49506933c27e5cd77608620baabbf81",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Даниил Якошинов-Гусев, cattingcat, кот, животные, cat, animals, Catting cat, telegram",
+    "nsfw": false
+},
+"a45d3ce29eaab48316477d0c075c4f56": {
+    "key": "e1309fdde06807993762641445d399c9e168ab052a4e3e76c8835dd0584a5716",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Котян Рисует, cattripkotypic, наркотики, коты, травка, животные, drugs, cats, animals, weed, CAT TRIP (@stickerssave), telegram",
+    "nsfw": false
+},
+"e1c46c46d00e8250cb3cb53b69944c13": {
+    "key": "20ebe1cbc2c1b3294c6cc2340a1f2638c182f006676fd6ea20c555b427cf2ec4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, catwhale, кот, кит, животные, рыбы, cat, whale, animals, fish, 🐳 Catwhale @lennysticker, telegram",
+    "nsfw": false
+},
+"1946f4712073fadcf52b031249131e3d": {
+    "key": "71585d0a3b535fa9e94751c568c128bb497de91b1205a6637d220d4555cb33a8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "celebration, цветы, праздник, сердце, день святого валентина, 8марта, новый год, подарок, gift, flowers, congratulations, telegram",
+    "nsfw": false
+},
+"6d3989c6fccca51224b2c8debde45670": {
+    "key": "9bf5322a34bee8e0777b8a4d23c7934407a4d13f856c95a78a5b7f5bcba95914",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "chancay, чай, мешок, tea, CHANCAY, telegram",
+    "nsfw": false
+},
+"1b238583fc3dbc37f13ffbdde7bf2833": {
+    "key": "0e051b1273d9100ee8bcfebb0ed7d4cb835e23af422adf84463d512e6402279b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Лада Поцелуева, chick, вконтакте, цыпленок, птицы, животные, chick, animals, birds, Цыпа, telegram",
+    "nsfw": false
+},
+"10db5a08feef4a33e38f888217c9167e": {
+    "key": "af6cdb89baeac00d9fe906ac334605fc5860832a2eca693ed4a91bc308c0ae40",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "MargoDamert, chimichangi, фильм, комикс, movie, comics, Deadpool, telegram",
+    "nsfw": false
+},
+"a716862c67750226df863e5e722ad0d2": {
+    "key": "a35caa539a31d6748b9616c2f5b9c76872ceded3443da7d53a70c9864180e039",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, chocolatedog, лабрадор, собаки, животные, dogs, animals, 🐾 Лабрадоры-шоколадки @lennysticker, telegram",
+    "nsfw": false
+},
+"2a91b4f237590490a7b74a109edfdae7": {
+    "key": "76c34454cf02e1e76421cd6ea10989f320ed0e604e997d3c783ddd845633d6ea",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "My stickers, chorni_Kotyky, кот, животные, animals, cats, Kotyky, telegram",
+    "nsfw": false
+},
+"81edce492499485c3d3a2c58b2b33909": {
+    "key": "7147ece97778bc5412116606a7235cbae87a071f93cf86f70383cbc22e8760c9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "cocoandmochi, белка, кот, животные, милота, дружба, любовь, squirrel, cat, animals, cute, friendship, love, COCO&MOCHI (@n_chronos), telegram",
+    "nsfw": false
+},
+"a837c16de54207a77e845d6e9ff4c493": {
+    "key": "d090af9bd8657093ec047e012a91abbec0c200930a66f63b9343b854b1b2f384",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "coffeewine, кофе, кружка, еда, напитки, утро, вино, вода, COFFEEWINE, telegram",
+    "nsfw": false
+},
+"7e5e61057c3fb6ace36302c1d4710d07": {
+    "key": "07ddf82e542bdbdc5d8b523c3e29a09a00af3a2771c25a5ac1c361225908e292",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "comics_vintage, америка, комиксы, america, usa, сша, COMICS, telegram",
+    "nsfw": false
+},
+"d09aead02dd62ae034a4e2c754f91357": {
+    "key": "4222ed1e63a1092568e7863b1fd7deabfcc7004a81b1f532fd7deed8d1e184c9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "cool_shrek, шрек, мультик, фиона, для детей, for kids, children, cartoon, Shrek, telegram",
+    "nsfw": false
+},
+"95c739c9f08d07956cdd46adcdf86cd2": {
+    "key": "2e71ec8995f9d3e8c564a96fe42b4ec433e393e1ef0594f09ce52be0db2dac7e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "CooMeet, coomeetvideochat, любовь, отношения, чат, парень, девушка, love, relationship, chat, boy, girl, Coomeet videochat, telegram",
+    "nsfw": false
+},
+"b38345cc722803e0eb0f7665fc9caaa9": {
+    "key": "c944ee78615232090f22f53c4148721fc3cb2e0f45a2f742f57c7dfc737b3638",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "cornella_joan, арт, art, fun, смешно, Joan Cornella, telegram",
+    "nsfw": false
+},
+"0f2f1f63dff45bdc688975cfffa0db4f": {
+    "key": "62337f01adf09852d7118cfc341344950b3144f2b3df47eaa5fc36566f561ccf",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ann Sp, cotans, арт, коты, cats, animals, животные, Cotans, telegram",
+    "nsfw": false
+},
+"616def6a952783500f032fea7b35ac7c": {
+    "key": "e04090bded5e4c3717e2deb671a5aeaa28c36a771ba803afd4c95621cda62666",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "cowbyliuhh, корова, животные, animals, cow, Momo Cow, telegram",
+    "nsfw": false
+},
+"cafdad876ad458c6967bef753330e7f4": {
+    "key": "2176f563ebafce7bc9aced0b1bf0c7d18aff3582c9575c1816b5a4ac0f3a7386",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Alena Baradaukina, cozyseal, тюлень, животные, seal, animals, Cozyseal, telegram",
+    "nsfw": false
+},
+"937fa08b6ad95faa1f05040aa1db6a71": {
+    "key": "d786df6a23c1367b34f753aef5d7a2d4bbbcb0098de9e90dcc9be6a4348d5643",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "crazyllamacom, лама, животные, animals, CRAZY LLAMA, telegram",
+    "nsfw": false
+},
+"60ce5c531ae79387b124ff1dbf866a5b": {
+    "key": "4ca4fd8570be62e70da7eb68be97406762f25f47ad5031ae37819f7ddc9230f1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "SEO BUBEN, cryptohoroscope, криптовалюты, биткоин, деньги, бизнес, bitcoin, crypto, Сrypto-horoscope, telegram",
+    "nsfw": false
+},
+"73a827d1fbb93616cea8202ed5827313": {
+    "key": "d8891c4c85705db111085114fd34f08c6fb48fb78d864d6b9c62149c87c7bf99",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Алексей Остроменцкий, cstmfemoji, comics, emoji, Fonts, шрифты, эмоции, чувство, отчаяние, досада, Emoji by Custom Fonts, telegram",
+    "nsfw": false
+},
+"72414e150530ccf1f637d7220ac3e106": {
+    "key": "31b1332b428f3e4877bab003c6bcc87d873a2e79a6143cd8af370340c09e019f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeria Fills, cuteWhiterabbit, rabbit, animals, животные, кролик, заяц, милота, White rabbit (@Valeria_Fills_art), telegram",
+    "nsfw": false
+},
+"03dfb6d7beaf940cab09ccec0807ae42": {
+    "key": "0f4e43327fc75bb6880b2a60756dd6d01633e248cd2bb3d1d02807a2c3dd61fd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "cute_corgi, собака, животные, корги, dog, animals, Corgi Dog, telegram",
+    "nsfw": false
+},
+"4f6e9d0b65b87fabe3537854406a35f5": {
+    "key": "7b0b6d45148ca24a12cc05d5d25cb588a59bc1ce5f1d3cbb1c8ebb8045887969",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "cute_sheep, животные, овца, animals, sheep, winter, зима, Cute Sheep, telegram",
+    "nsfw": false
+},
+"ffbf69df5a21d54d4400160eaccd1162": {
+    "key": "5c192413ccd9ab8a0d2ab585442ed00943118dd6eecea0b9adcefb63bb4ff26a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Виктор Костенко, cute_smile, смайлы, эмоджи, emoji, Смайлики на 👉 @StickerManya, telegram",
+    "nsfw": false
+},
+"8cd43c894d84b0a85532628e6fb42520": {
+    "key": "b79e6ba276149cdda2cff1eb016e65d9ce790f23a7a633c83db69b6d904f3cb5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "cutebabystickers, дети, младенцы, мамам, родители, baby, mother, parents, children, Baby Stickers, telegram",
+    "nsfw": false
+},
+"b425252ff4b49db77ad569d2aef62e32": {
+    "key": "bac9255343ae3771e1c2e5098c4c59631b9582e537a31fb40f421c0a81720238",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ksyu Eroschenko, cuteshibainu, собака, доге, doge, dogs, пес, animals, животные, Shibainu, telegram",
+    "nsfw": false
+},
+"582f7df7888480d232d7388e9e2da971": {
+    "key": "772438f0ee67111fcc032652f870c0db03d240ffa4978bb84dab11f3c18ce5f9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "cutewhales, feash, animals, sea, море, кит, рыба, животные, whales, telegram",
+    "nsfw": false
+},
+"cf8b0aa844aec3a1461a75c912e73e52": {
+    "key": "2caaa5eb7aa1ebda4b64d3a2ac530461ca88056c8778350dd52c3507a77c9f92",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Катрич Маргарита, deadbydaylights, games, DEAD BY DAYLIGHT, telegram",
+    "nsfw": false
+},
+"279290af400537bf9c7a88f2461a2d73": {
+    "key": "5e62b9cbcd77c78799419249e1908be969ef24efa0d55febafd4db3c2ba6e658",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "devochar_kosulya, косуля, животные, roe deer, animals, Косуля, telegram",
+    "nsfw": false
+},
+"979aa34a68a030e3e69e6a5aa8a21bba": {
+    "key": "c34253c496c137c29c72d10ea4127f6d86d94778d0387a245a00f0f1728e3192",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Эдуард Пономарёв, dolphinalcoholic, дельфин, животные, Dolphin, рыба, fish, Dolphin alcoholic @dailyponer, telegram",
+    "nsfw": false
+},
+"c0033bfdedf4da97aaddea592205a229": {
+    "key": "dd967a690589f68c7af00c85670a3ccee77f7f8c4d0b653983763c3f23ab7319",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "chroneco.deviantart.com, dotastickers, игры, дота, персонажи, dota, games, gaming, warcraft, Dota Stickers, telegram",
+    "nsfw": false
+},
+"b9b18c6dfdd8de679ad8bef08bf8d90f": {
+    "key": "b61fe6ffccd37cd57ebf64b0db042dc1b6f8601c608a3984671dc4b3e7d1164b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Undead Garbage, dracogeco, дракон, геккон, животные, dragon, gecko, animals, Draco-Gecco by @peps_i (@stickerssave), telegram",
+    "nsfw": false
+},
+"7d54b78c8bb31ab63ec7ddbf59628a5b": {
+    "key": "443f9f55bcd9d51bb109ae01134eabe57ab5a6cdd634e2bac5ed94892d3a41d3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "drakoha, animals, животные, дракон, Дракоха, telegram",
+    "nsfw": false
+},
+"2ddb3b4e395dc85a887bc680793a7516": {
+    "key": "1aa2dd9fa91c8ff09dbab03326795201fe6bcec3c2b5c636dc00af21bfa961c6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Raindropmemory, drawing_stickers, art, drow, искусство, арт, рисовка, Рисовач (@stickerssave), telegram",
+    "nsfw": false
+},
+"5b70476eaf29134e6b85bab5812dfc7d": {
+    "key": "7c55d12d6ad5a60a8d87b8d92adfb4df9c7af43330c99508da29564c1d14ef3c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "drawmepls_stickers, pictures, drow, рисунки, animals, cute, милота, животные, drawmepls, telegram",
+    "nsfw": false
+},
+"a610ff0c4266bed9053ee799044241f0": {
+    "key": "c24cc5bde73371444595e00e8ac5dcceb46c38e6891baad2ba5b7091e90628dc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "dudll, человечек, эмоции, emotions, Дудл, telegram",
+    "nsfw": false
+},
+"f6be94d227dd0b37e138c7643cce15ea": {
+    "key": "bc050ab4eed720ac187dfa4921e9dcafb1d9418d238f60530b46634a4f5936dd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Мария Брунс, eleanor48fox, лиса, животные, fox, animals, Eleanor48fox, telegram",
+    "nsfw": false
+},
+"4dc18de4edaf0b14f17b1677841ce48f": {
+    "key": "8fb66269d0253aee09c8a27f75d6cc65e7c8e1476496a231f6f2958a6615ea8b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "elphy, арт, art, animals, животные, Alireza Jafari_baby elephant, telegram",
+    "nsfw": false
+},
+"708c8d5d16a56719f7b8e0a3b66cd0c3": {
+    "key": "ef7ba1c07bf1ca6143581dcbcad1179cf9b2f520c36d8c576ab9ba48232a99c7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, english_bear, глиш с Медведем @stickerus, telegram",
+    "nsfw": false
+},
+"3f72663b064f57dc8f64664a2e96d292": {
+    "key": "e3cfe1908dc659c9b8d8944279f3eb8648a75b22cb7e2a58bcfd08d00c213898",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Customwritings, essaytime, сочинение, текст, писатели, авторы, text, whriter, Essay Time, telegram",
+    "nsfw": false
+},
+"9fc603d469bf6cf4b43d1fbbe06780c5": {
+    "key": "ffd97752115e298d3ab8ef344a299f24f8989a405eafca70ced9611a973f4d0f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "explosm, комикс, юмор, humor, comics, cyanide&happiness, telegram",
+    "nsfw": false
+},
+"b2c5d9067b9c26d41c304ff1e4f51f63": {
+    "key": "12d9fecc6c9ba01a5bb8516681c827ae403563af4e5c96b18a9b159e541eaf1b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "facecamru, cat, animals, кот, животные, facecamru, telegram",
+    "nsfw": false
+},
+"7622631dcc8bb05704970a731d038a23": {
+    "key": "10ad7797f2a22a8c1aeee6f6bd184a1e92bb37e0a618c718d6768b086f1ef547",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "facepalmstickers, лицо, ладонь, отчаяние, грусть, горе, безысходность, печаль, сожаление, тлен, безнадега, Facepalm, despair, ashes, sorrow, Facepalm Stickers by Gudim, telegram",
+    "nsfw": false
+},
+"6fc2ba0c3ca701d93a2702d6849251f2": {
+    "key": "e83722d42350166c211cbd945113350137bfefc1d9104fefb98b4602b52a2586",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Warner Bros, fantastic_beast_new, алло, google allo, Fantastic Beasts, Фантастические твари и где они обитают, Fantastic Beasts and Where to Find Them, фильм, кино, книга, movie, book, Fantastic Beast, telegram",
+    "nsfw": false
+},
+"bade6321eeffc151c4a096a42addfcbd": {
+    "key": "a4ee789327021064f9b6e0e454872ef6bbd4f23ef1741a7b6ba3aa02d7516fa0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mostropi, fb_opi, медведь, животные, animals, bears, Opi (by Óscar Ospina), telegram",
+    "nsfw": false
+},
+"3511934c77d1af7dfef2cb28686a3279": {
+    "key": "8022b9f229b7bacaf5c509dda5ac4b2a646b9ed1352ce064aa0a25e4857fa93a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "feelsgoodm, мемы, memes, feels good man (by @lampochat), telegram",
+    "nsfw": false
+},
+"01ddd84e0f8b742d574df46ed4eaa5c1": {
+    "key": "47e12336835fc06bb4ccdc0165b5dc07fd2a14ee8cacfa1fbe74cb2cdcc60b98",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Котян Рисует, femicatsbykotypic, кот, животные, женщины, феминизм, cat, animals, feminism, FEMICATS (@stickerssave), telegram",
+    "nsfw": false
+},
+"c7c22194b97d83899075b8962355ce99": {
+    "key": "063b26d07976f55a1c90ecb005c0acbf11869bbd4a70a42cae1e7dff4a8f211c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Anna Triffin, fish_madam, рыба, животные, animals, fish, Fish madam, telegram",
+    "nsfw": false
+},
+"13ad39be44ebb866992b1e2d8ebf5d2b": {
+    "key": "14c68b493d4ef8cc653a372b91e4087a0f37e67a4dc5973806ae5e0728b4561e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Fishdom, fishdom_mobile, рыба, fish, games, игры, Fishdom, telegram",
+    "nsfw": false
+},
+"0108109a88b4799fc949d0bbde6a577d": {
+    "key": "2d154a5c7ce3964a6078b97fc6bce9980c6d1eb6b77b317c49194ac7090d8966",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "fixel, кот, животные, cat, animals, Fixel the Snob Cat, telegram",
+    "nsfw": false
+},
+"4fe50953144a4b447a9341bc85358d00": {
+    "key": "002be3eab58ccacb29cf256d7b9feb56d46dee8088852c07aff53020b2c82ec5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Татьяна Разгоняева, foksi, вконтакте, животные, лиса, animals, fox, Foksi, telegram",
+    "nsfw": false
+},
+"78bc6204a2b7478bc7ceba1a02df4ded": {
+    "key": "b0e0af31cb516a7b09fd8ea950794f2dba9f59590fe9b07faabb11458e4b08f1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "football_players, футбол, спорт, игроки, Пуховик Венгера, Ван Гаал, football, sport, Football, telegram",
+    "nsfw": false
+},
+"30cced93aae001df395572c34cc23ab0": {
+    "key": "08cea7e8527106eb9f8458ba4329fdc14849393e208bd459ffcd813ea0817f94",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Anton Andreev, fox_vk, вконтакте, лиса, животные, animals, fox, vk, Fox :: @mosticks, telegram",
+    "nsfw": false
+},
+"1c1e5065d1bd71c7a878cae949a688cc": {
+    "key": "43442dcc44968601e02b440299bb01e8868833f16ba820adf52e267f0111b61f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Agency [f]-PR, fprstickers, спорт, чм, футбол, soccer, football, питер, россия, санктпетербург, петербург, From SPB with football ⚽, telegram",
+    "nsfw": false
+},
+"f5c0573a8c3e885561551aa0a39fe984": {
+    "key": "16eb4c98e72bc01834907de9841dd1756dd58d2a7a2883d4a37dd60ad5bea38c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Тамри Нижарадзе, frankthewolf, животные, волк, animals, wolf, Frank The Wolf, telegram",
+    "nsfw": false
+},
+"f5f9f5eeeabe264427ddc9bd7dcdbd81": {
+    "key": "cbffd04a44fe1d7cf01a6ab41d477f1b44860d917cfe6a61e01ab44398aa395b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Frannerd, frannerd, девочка, девушка, арт, авторские, girls, Frannerd, telegram",
+    "nsfw": false
+},
+"c8e6ddddf471171912f6ae06a0ebe8a8": {
+    "key": "bbef547447e9346b98aa4e1b723f244b629e5d6320d4b97b3de5ab3c6467c5c3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Arn Wald, friedrichthecat, кот, усы, животные, animals, cats, FRIEDRICH THE CAT, telegram",
+    "nsfw": false
+},
+"fdeb28c1305fa5c3da9e24528beff147": {
+    "key": "5c5e27e218234b5eaabf3725d29539e00bd7b6ad1ce270dd1c7c84c2010f7ebb",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "friendsbysmol, сериал, друзья, фильм, series, tv, FriendsBySmol, telegram",
+    "nsfw": false
+},
+"62b78b9f1864094ba98105e8f46c3960": {
+    "key": "e1db4f0d9ea0bfbd01b6a02056bd8bdb18d21dc33f91c5393e81557e56c7cb2c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Татьяна Гейнце, frosti_vk, новый год, зима, вконтакте, полярныйлис, лиса, елка, поздравления, Фрости :: @stickroom, telegram",
+    "nsfw": false
+},
+"4502eb74f1294a9e674e16b1663dc69b": {
+    "key": "7f5a79da59c6ff5072dd338140192d5fe09aab07c2964f9e04fcb3365f2b6dd1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Andrey Yakovenko, fruitvegetables, вконтакте, фрукты, овощи, яблоко, груша, ананас, малина, клубника, вишня, лук, fruites, vegetables, apple, pineapple, pear, raspberries, Strawberry, onion, cherry, Фруктовощи, telegram",
+    "nsfw": false
+},
+"21c57a58e3501ccbc64986712b462d55": {
+    "key": "a4c98a4dc00083466d74e814a6af15d0e41a3d62ea3cd175a218e9b79ff71ed0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "2D Among Us, futurama2d, 2D Among Us, Futurama, Futurama2d, футурама, 1д амонг аз, Futurama by 2D Among Us, telegram",
+    "nsfw": false
+},
+"c8c83285b547872ac4c589d64a6edd6a": {
+    "key": "59bb3a8860f0e6a5a83a5337a015c8d55ecd2193f82d77202f3b8112a845636e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "20th Century Fox, futurama_pouyasaadeghi, футурама, зойдберг, futurama, series, zoidberg, Futurama, telegram",
+    "nsfw": false
+},
+"7375a3d75ba022cf7e26af2a1a0b3cb9": {
+    "key": "6826f1adb1c66178fca6a6fb2d3999d901247e934ea63c0f473a53b00e4021bc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Евгения Гапчинская, gapchinska2018, арт, художник, дизайн, картины, иллюстрации, любовь, отношения, art, love, Gapchinska, telegram",
+    "nsfw": false
+},
+"972ac8b4ed4c04eeda03165ffa9fb3be": {
+    "key": "56ff0a467f0922dbb2d8d0977d2dc4bcf9c8da01b1d88696d817c449454cc656",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Gardenscapes, garden_mobile, игры, games, dogs, animals, животные, собаки, Gardenscapes, telegram",
+    "nsfw": false
+},
+"30ec9a3d9f7ea611040ec80cd492b976": {
+    "key": "4d0b77485ffbe44e53226efe7c91f9e0063ab61b20fe83c2f36a2cce17617fc7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Nik Cristian Dzwonik, gaturro2018, gato, animales, кот, животные, мультик, cartoon, animals, forkids, GATURRO, telegram",
+    "nsfw": false
+},
+"42a31c8ae6f921cec836315a244b7b68": {
+    "key": "1f8e3ca4c5a7b50618d680be258cced8a8d9f335ff93e6842a29ae09b3c0b6eb",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, gendalf1, гендальф, фильм, кино, gendulf, film, cinema, ⭕️ Gandalf (first movie) @lennysticker, telegram",
+    "nsfw": false
+},
+"732914c284288655428a5c33485d667b": {
+    "key": "ec3908b021af029e6db16540622e05c532758f778054731a742d939514ff810a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Яна Клочихина, girlpower_sticker, girls, women, 8 марта, международный женский, Girl Power, telegram",
+    "nsfw": false
+},
+"57ab01dbc17169af793b17c7b4d6a1f5": {
+    "key": "a1c2beb3ac98aee059da5498981352f9dbf25131620d55b473a8238907316f76",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ana Kovi, girlsandwine, вино, алкоголь, девочки, girls, wine, Это винишко, детка, telegram",
+    "nsfw": false
+},
+"1d18f039d4a50aec610e68644a6390bb": {
+    "key": "46d7d404b8adca54eedd97820377ff49efae23d6f7b8143b1a2ee5eac8c7936d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Cotton Valent, gloomycat, кот, надписи, фразы, животные, Cat, inscriptions, phrases, animals, мрачный кот, Gloomy Cat, telegram",
+    "nsfw": false
+},
+"068421fae7fe9ee2f286166b481ae8e1": {
+    "key": "c058ddd9d8e0aec4c94001ee598b92d8d460b167665b3472d2b8517e8785e973",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "goodadvicecupcake, cake, food, еда, капкейк, выпечка, thegoodadvicecupcake, telegram",
+    "nsfw": false
+},
+"d31895b927573ff2fba453fc2c3d2a65": {
+    "key": "756bbecc8133da27b7f2b0555008f58a9543d28ea129bfc85633306e2523252f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Gordons Pink, gordonspink, алкоголь, джин, выпивка, alcohol, gin, booze, розовый, фламинго, pink flamingo, Gordon's Pink, telegram",
+    "nsfw": false
+},
+"1303cc4a134e96acc6480b2bec174b8d": {
+    "key": "b221222c1f88e8558fc9990331c04f3d76fa81235da07412ef0dd67ff33ba038",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Михаил Голубь, gribson_vk, грибы, вконтакте, mushrooms, Грибсон | Mushroom, telegram",
+    "nsfw": false
+},
+"63daa9dfc3cec9a24268be4524a45b2b": {
+    "key": "c9f077b78d8403eb41a1ac47756c671cc0d7192edaf9289b4d2abc309dccded3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Волощенко Виктория, halloween_pumpkins, halloween, pumpkins, horror, хеллоуин, тыква, ужас, Halloween Pumpkins, telegram",
+    "nsfw": false
+},
+"f12f9efbb5ad370a90ee46a82ce63c89": {
+    "key": "dfe7d5a3de86112d64ce50b5d17bb48d41a20fa024427098aeb9126feec7f687",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "DreamWorks, happy_madagascar, животные, мультик, бегемот, лев, зебра, жираф, для детей, animals, cartoon, hippo, giraffe, zebra, for children, Madagascar, telegram",
+    "nsfw": false
+},
+"90f7677f2aea7904b4931ac6dfdddcc1": {
+    "key": "1765fe287d898ab0661ac1431598da76d1a7ba03482e1f8086d2ae7e0e06f902",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "happymelon, food, еда, арбуз, фрукты, watermelon, fruit, watermelon, telegram",
+    "nsfw": false
+},
+"f469c23ad9bf8b9fc56a569a6e5c6bef": {
+    "key": "13f115c9eb95ef95d93086ab49c13b333db714b7d34a32aa51fef1bed5400aea",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Hozo, helloRyan, лев, животные, animals, lion, Hello, Ryan!, telegram",
+    "nsfw": false
+},
+"22e5e0738b7e71c400ce7f9d168ab360": {
+    "key": "658eeb70668bfb5a3d378622c43b5b23cf3b951c955a89ea204be939f8e27e79",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Pavel Zametniy, hellokaka, какашка, shit, poop, HelloKaka, telegram",
+    "nsfw": false
+},
+"3202b6718469937b3eb0da5aac7a1c14": {
+    "key": "8e876e8a592d0b853ae6f5852525c117cad11c4ec7e59b8864a4f783b3a017bb",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "hihelloholla, комиксы, девушки, арт, art, girl, ARMANA, telegram",
+    "nsfw": false
+},
+"3036e5533d5b92e5a86e931f70a3c0dd": {
+    "key": "04e42275141c1378db1e6657d0c72b1c868b6429cdb18a363dccae77f5f35dc3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "hipsterllama, лама, животные, llama, animal, hipster, хипстер, hipster llama, telegram",
+    "nsfw": false
+},
+"fdb2a1a034fb71a98101e6cfbb27f31e": {
+    "key": "8e7b36b787bf2a2f41b355844f97a5439bf3f7257a0fdbae5d675dd56c5ff900",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "howreyou_stickers, фразы, английский, phrases, How are you, telegram",
+    "nsfw": false
+},
+"28546a14022eeaef87a4fd8a85130744": {
+    "key": "1c174d7fcd4e91c84d404c615cf73d847cdebb1e63a4b6e37cb8da4e81c13877",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "hug_me_iam_your_cat, животные, кот, милота, cat, animals, cute, Hug me Pls - Iam your Cat, telegram",
+    "nsfw": false
+},
+"bb8cc786a2a55014d6ecb771cc25b58e": {
+    "key": "1c13a627be74c78aa7e3b83f0157b1b96133338e3d9da5c94546957cd594f151",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ice_age, мультик, для детей, сид, белка, орех, мамонт, диего, опоссум, for children, cartoon, opossum, mammoth, seed, squirrel, Ice Age, telegram",
+    "nsfw": false
+},
+"4dbcfb03ad7d4b0cae1f0fda26838e7f": {
+    "key": "dbc690c0850eb74cd01b37af672e66066c2ab80bd97c1eb11072f8f0a8d61b46",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Daria Lukashenko, ihraprestolov, сериал, series, Game Of Thrones, telegram",
+    "nsfw": false
+},
+"532911840b35ebbd6a6cdd2361cf922b": {
+    "key": "19d06e3da44a2904976a233b441e741e5b6d7f67d0adeb157e6fe022f511d370",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Новожилова Светлана, imagirlbylanalama, cat, girls, pink, розовый, девочки, длядевочек, кот, животные, I'm a girl |By LanaLama, telegram",
+    "nsfw": false
+},
+"df13c66b8d772db515d0f724059f5dd2": {
+    "key": "c73b232956428a1c59486f8662c32228b3546fe304bd105c1542e2e65c02ffaa",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "imojidex_poop, Emoji, poop, какашки, эмоджи, emojidex, telegram",
+    "nsfw": false
+},
+"29a2d659f61e1bc0d877ef715e84e9eb": {
+    "key": "c818f967e1467c6b7b9c1d4fe2f4c608b99b3ed51adba5a0406d29c4a27cb824",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Валерий Матюхин, inlove, вконтакте, любовь, отношения, поцелуи, обнимашки, влюбленная пара, kiss, relations, love, lovers, деть святого валентина, 14 февраля, Lovers, telegram",
+    "nsfw": false
+},
+"771f1fcc8b81215ed32c89cee939b049": {
+    "key": "ad1f921c24d149daed85385189d355490a47c280c4edf4b4e66f14eba51ce09d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "internationalfootballstars, спорт, футбол, sport, International football players, telegram",
+    "nsfw": false
+},
+"87c98bfbb12d8697f53cb17d2f129c96": {
+    "key": "591438e6c2ef81ca37009c3dcf0ff03aa9708f49fe91c603b37b2a0aef6202b5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "it_youstickers, кинг, фильм, оно, it, king, movie, @youstickers it, telegram",
+    "nsfw": false
+},
+"e3ce0cf87aea73f2b2407203bc2a338c": {
+    "key": "2f09652f4120a4874bc2e1331208dc530a49e74a952d2200b800cd6104780378",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Dima E, itchyandscratchy, симпсоны, simpsons, cartoon, мультики, telegram, The Itchy & Scratchy, telegram",
+    "nsfw": false
+},
+"614cc483bf3afa0a88d684716a27a058": {
+    "key": "259fa6014e1c1ef78c1b61fd2b7b3d6c97d53ab598c886abd99cd015be21ae95",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Artem Bizyaev, j_and_sb, фильм, movie, telegram, боб, джей, Jay and Silent Bob, telegram",
+    "nsfw": false
+},
+"34cdbe7feea9fa35f19815d30ccbf363": {
+    "key": "b6f3e9a07744a77150566c602d7f66862a3f2dc447c887d9db9b93b11f64675a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Jägermeister, jagerhalloween, напитки, алкоголь, смерть, ужас, хелоуин, drinks, alcohol, death, horror, halloween, JägerHalloween, telegram",
+    "nsfw": false
+},
+"51ed28e14ce1c97d2954e92f4a622a09": {
+    "key": "f12679d7e6a92ee2f828aa13e7ea22fc9d52c30d426ad9258e49864e927e276a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Jane Massey, janemassey, кошки, собаки, дети, книги, иллюстрации, illustrations, art, children, books, janemasseyillustration, telegram",
+    "nsfw": false
+},
+"4710340f85bcf45c75073c33aba67e5c": {
+    "key": "ee5a78387a2756c02e43f727814809fc926a13bbc1b018f259f37e12468cc49a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "jellyworld, желе, еда, food, jelly, Jelly World, telegram",
+    "nsfw": false
+},
+"cd34b21e6b2cf09d8f3b8de37e3f8be0": {
+    "key": "4164e08a1256176a5d64ec60a51e69bb6cb07f58b278dfb6eee0ad59fc669e49",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Jenny Meilihove, jennymeilihov, картины, искусство, арт, paintings, art, jennymeilihov, telegram",
+    "nsfw": false
+},
+"4e303b89a6562d71837605ab3796b716": {
+    "key": "26e85506dde8c9ee955c1e6481e91ebf92fff7d1cc10fecd2ff19ace465667ee",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "joiny, животные, кот, cat, animals, пантера, panther, Joiny, telegram",
+    "nsfw": false
+},
+"df1141a1a7471a447c71e1610add23dc": {
+    "key": "1cf4181b90e1dd71b6976112dbc73e47fbdf7d0760c8e075bf62b6125109968e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Леся Гусева, k_shi, белка, животные, Protein, animals, надписи, фразы, kroshka_shi, telegram",
+    "nsfw": false
+},
+"87763dbc8df66ec9f5fa252c9a32f8d3": {
+    "key": "fbe276a371ca4e11983210a7c8f3298b4fc05c657e905931794b8cf395e489a2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "kakao_apeach, персик, фрукты, еда, peach, fruits, food, apeach, telegram",
+    "nsfw": false
+},
+"6ae05cbedced3e5057d30421ddc77501": {
+    "key": "10d23a4e82a00f34a8a9b67e6051c0573e05938bbd9260aec639208993a1e4c5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "kandrelfox, лиса, животные, animals, fox, Kandrel Fox, telegram",
+    "nsfw": false
+},
+"3833c22d19159f305c34834f08958bda": {
+    "key": "619782d2615c50e98ad394b297f34f807e50186895524c92797605ca71bfc128",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ketcoyotes, собаки, животные, dogs, animals, ketcoyotes, telegram",
+    "nsfw": false
+},
+"57788861a7ea13d8eb726cb8b3c6be0c": {
+    "key": "a0f664101ddc161e9e19be9b856771c1b4fc48801d72f34096e724c8b3b0775c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ketniiiiiipz, абстрацкия, розовый, чудик, блобби, pink, comics, комикс, фасолинка, ketniiiiiipz, telegram",
+    "nsfw": false
+},
+"1ede77474e10f7d1880795ae5e08fb4c": {
+    "key": "72e3dd565b52b0169c5fb522ef1e2872b4c486ed0c1655347c124a4a729ca0be",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ketnipzz, чудик, иллюстрация, монстрик, человек, art, pics, Ketnipz, telegram",
+    "nsfw": false
+},
+"0d4c729da9e5246a890199a1933ebc33": {
+    "key": "a644fdb826281dbba12c471079e72afd9ddddd4c9294c380f5b77199090b41f6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "kidecats, зима, новый год, праздник, кот, животные, елка, рождство, winter, new year, holiday, cat, animals, fur-tree, christmas, Три кота. Зима, telegram",
+    "nsfw": false
+},
+"4b43d289b90c6f1069593b937a15ffcd": {
+    "key": "2f4afa2350e967b841287067eccb5052d3425c69ed18b1a551b38b2de943de81",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Паша Лысцов, kimkorea, Ким Чен Ын, корея, политика, Kim Jong-un, politics, korea, Kim Jong-un, telegram",
+    "nsfw": false
+},
+"ea877f12157db2c89a85f833d5334c6f": {
+    "key": "9fe80710e1887af1e5bc4501c0c94063718f032a68bbf4b2853619a0d76227b1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "kitten_spb, надписи, фразы, кот, животные, санкт-петербург, питер, рыжыйкот, петербург, россия, города, Kittens, telegram",
+    "nsfw": false
+},
+"3a434e8ae4888ced66a377f705523d8d": {
+    "key": "fb49932e8f0f218b47b845135b0a7da806abd86eb3a1df1e8d581313d3bdf3c0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "korgeredackion, собака, животные, dogs, animals, korge, telegram",
+    "nsfw": false
+},
+"65daeda19ac83225c6c432322489f2c3": {
+    "key": "7cd72497f4181aa8940c97436b89579634dd62160c32cf8788c8979a5f1b0047",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "kotenoktaffi, кот, животные, котёнок, милота, cat, animals, kitten, cute, котёнок Таффи, telegram",
+    "nsfw": false
+},
+"66a831c04de3b3beb28522d76489f0b5": {
+    "key": "6a9b6edae4a0256763fee2a469e439ff51521e1db3d8c07eec9119ad27351234",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Жан Аллен, kotya_mur, кот, животные, animals, cats, Котя, telegram",
+    "nsfw": false
+},
+"cfa777355fc3862e7a8e59610b85d01e": {
+    "key": "f5a54ce47000498f17a9e7a6eb91b97f932cb6076f0e5acf2b2e6a475fbeab42",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Екатерина Борисова, kozaroza, goat, animals, коза, животные, Козочка Роза, telegram",
+    "nsfw": false
+},
+"4710692d80eef97f9883cd9dc7d22aab": {
+    "key": "4f4670296156311d38cd92ce67909e39205ca20534be2d3175660892adeb72ef",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "DreamWorks, kung_fu, мультик, для детей, панда, мастер шиф, мастер угвэй, тай лунг, животные, for children, cartoon, panda, Kung Fu Panda, telegram",
+    "nsfw": false
+},
+"3ae3d8372fe07ecdf926be8a3ef7e681": {
+    "key": "4503f0965d6c74310fdfca270a94a508411256d3ad53226c9e6de9308731df56",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Михаил Голубь, kuper, вконтакте, животные, собака, щенок, animals, dog, Купер, telegram",
+    "nsfw": false
+},
+"071480f33cb35972c2fb7408ad345f28": {
+    "key": "3bf01f5ba989b01a300d4789e3185d71a1ecccb24c66d7daede1f4cdada30c55",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Gulnara and Elvira Nisapova, lamore, вконтакте, животные, отношения, любовь, романтика, поцелуи, love, romantic, kiss, animals, relations, день святого валентина, 14 февраля, Ля Мур, telegram",
+    "nsfw": false
+},
+"20dc6e2ad64543cb4a81a6b1250e4348": {
+    "key": "38d96ca93e46b2dedda5f04c1e585003d737e5acc1ec81c52c1a85d1c961208b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, lennydeers, олени, животные, deers, animals, memes, мемы, 🦌 Mem deers @lennysticker, telegram",
+    "nsfw": false
+},
+"9b21abd6c0a742c31d010ef7ebeeabcb": {
+    "key": "9abc8780f2958061ad1c11181bf8c02a54423ad70dc44d7d5b0950e6e10ab0e2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Elena Fuks, lentov_cats, коты, животные, cats, animals, LENTOV cats, telegram",
+    "nsfw": false
+},
+"85c980f92388d39e3b325c658f1421a9": {
+    "key": "c9bccd93478a362903c030a2c916dc502ee5999bbf96a54d6c812d507bb3c415",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Гузель Гиззатова, levleo, lion, animals, животные, лев, Лео, telegram",
+    "nsfw": false
+},
+"e849bab83bead81e934ed12e1c18f701": {
+    "key": "327eccdd79af891a7f3e01217ef356dec40673da44a1269ba8f0881f020ffd96",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "line1126380_by_Sean_Bot, cat, animals, животные, кот, Cat lying down    @SeanChannel, telegram",
+    "nsfw": false
+},
+"5ce147fe8814cf37a68fdcbf27685409": {
+    "key": "8b5e7c4c59ca922e596b0206dc206dfe5099b40396aae8579aa450bae7326741",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "VK, llarry, ленивец, животные, вконтакте, Ларри, telegram",
+    "nsfw": false
+},
+"1268e935de9b5c3ed52608ab7b4a9af7": {
+    "key": "81f98d5bf750baf8562e4a2c62246295399f2112c7cbb5743cb588982aab5df6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Yulia Khartsyzova, lmp_vk, вконтакте, монстр, monster, голубой, LMP, telegram",
+    "nsfw": false
+},
+"cfadf37758f337160fece071f284dda8": {
+    "key": "18d4fd61f413a226f6d0c9597bf8db710a69375a05932eac8d1f245f06a702a5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "love_chicken, цыпленок, курица, птица, chicken, bird, ЦЫПА, telegram",
+    "nsfw": false
+},
+"4f142d130a0bc6c985798cedc63b34ab": {
+    "key": "69c6200ddb485fed2956d08e7bf4d29ed359ccece5959567936dcea8b3acef9b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Исмаилов Шахзод, lovepuuung, love, relations, любовь, отношения, Нежная любовь by @Deutschd, telegram",
+    "nsfw": false
+},
+"a0a6829b451c53879898becf99bcf0ba": {
+    "key": "1b864b1bb8a0b03b13b3a651f492caca230a9d4c49bf5a6fa7f633fb8d510b77",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Anastasia Zhdann, magic_routine, люди, эмоции, emoji, people, комикс, comics, Magic routine, telegram",
+    "nsfw": false
+},
+"375f52b0ee4a1b26bd11bb85e50e9830": {
+    "key": "262b160276aefed8743765cb10343131e169353f136ad294fa277a40e4a5b32c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, manulpack, манулы, животные, коты, manul, cats, animals, 🐾 Манулы @lennysticker, telegram",
+    "nsfw": false
+},
+"483caf25818f597ed031713180848d7e": {
+    "key": "f85c1fcca64d545e929987c8b355a055c1524810ca51124ad846b5676da0cddc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Валерия Фортуна, marie_vk, вконтакте, женщина, девушка, жизнь, отдых, female, girl, recreation, Мари @TgSticker, telegram",
+    "nsfw": false
+},
+"a1a68e0d26fe43e5a7ea7b9950277da6": {
+    "key": "b1efbb770c118f3e27a568368866336632b7918c07245d623394e4deb4e11d78",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mary Freyman, marystirerrrs, memes, cats, animals, кот, животные, мемы, marystikers, telegram",
+    "nsfw": false
+},
+"e51962a2cd8c975436a98b1e9093c26c": {
+    "key": "5564b3b40d1ef7dd5375eb3311bfa1c7ecd9290f03a6c1a63f43b2636ca5d5d6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Мария Шендель, mashendel, арт, авторские, девочка, art, girl, mashendel, telegram",
+    "nsfw": false
+},
+"e19546ade4744af6b746d48a79ad8f4d": {
+    "key": "42b044676e3558aa3252e57132f07f96021985d04941dce35772091944aa8df3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "masiil, кот, животные, черный кот, animals, cats, Мася, telegram",
+    "nsfw": false
+},
+"4cd4e87eb9afca0a9364f7a9a90f0f92": {
+    "key": "d9da29a0a726967eedf417b592d241174fb3b32d9dfc4783af7a35b6e071a5c0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "masks1, маски, уши, животные, глаза, слезы, парик, усы, борода, коса, нос, корона, шапка, цветы, венки, рот, костюмы, платья, одежда, надписи, ears, animals, eyes, tears, wig, mustache, beard, scythe, nose, crown, hats, flowers, wreaths, mouth, costume, dresses, clothes, inscriptions, Masks I: Party Animals, telegram",
+    "nsfw": false
+},
+"a8e1c5c826d88d1ceefac5436b8489e6": {
+    "key": "7ca3a1feb9cb22057e0ee657a5a6d317955f998b36aff610d0bde1e49d1cace7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "masks2, уши, животные, пепе, глаза, очки, нос, кровь, морды, рот, губы, парик, прическа, шляпа, еда, пирожные, печенье, пончик, мороженое, мысли, надписи, ears, animals, Pepe, eyes, spectacles, nose, blood, muzzle, mouth, lips, beak, hairstyle, wig, hat, food, cakes, biscuit, donut, ice cream, thoughts, inscriptions, Masks II: Face Lift, telegram",
+    "nsfw": false
+},
+"ead2edcd4e8c3f5f5903153c1b95a961": {
+    "key": "c7313b400ef86ca13f80dcecb203e6c4d52be8a0e39d4157875744c82749535c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "masks3, маски, очки, ожерелья, бусы, шапки, солнце, радуга, погода, борода, glasses, spectacles, rainbow, sun, beard, hats, necklace, bead, masks, короны, crown, inscriptions, надпись, i love you, я тебя люблю, спокойной ночи, good night, кекс, морожное, ice cream, cake, платье, костюм, costume, dress, Masks III: Costume Party, telegram",
+    "nsfw": false
+},
+"b825a7108f428782a4570ff475465b50": {
+    "key": "5ff227cad9d9f17723ec1301eb082f5cb7299e282b8753a9750d310e5063a8a5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "masks4, маски, masks, очки, spectacles, glasses, борода, beard, усы, mustache, парик, wig, уши, ears, глаза, eyes, волосы, hair, нос, nose, beak, клюв, монстры, monsters, клешни, pincers, мозги, brain, яйцо, egg, викторианская эпоха, Victorian era, шляпы, hats, шапки, цветы, flowers, викинги, Vikings, корона, crown, рога, horns, руки, arms, суши, sushi, оскар, Oscar, ангел, angel, еда, foos, костюмы, costumes, супергерой, superhero, звезды, stars, пчелы, aliens, инопланетяне, inscriptions, надписи, boom, Masks IV: Elements of Style, telegram",
+    "nsfw": false
+},
+"850882bffdcf3f814f3f1dcd701f09e5": {
+    "key": "24866a114e7ffc492f7cbb0f5a2e06a9117d74ef5df1cefb79b4b81e52b18fff",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "masks5, маски, masks, животные, animals, клюв, beak, глаза, eyes, клыки, fangs, кляп, gag, роза, rose, зомби, zombie, вампиры, vampires, поцелуи, kissing, деньги, money, презерватив, condom, череп, skull, противогаз, усы, mustache, ганнибал, Hannibal, мозги, brain, парик, wig, рога, horns, короны, crown, одежда, clothes, тело, body, inscriptions, надписи, Masks V: Masquerade, telegram",
+    "nsfw": false
+},
+"be095501f4a62fed3c6a050b3cf74882": {
+    "key": "ce8775b33939c0bac5c55aa51c22a57697de843076c7cc2a4e66239e69f8d8f2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "masks6, животные, animals, головы, лев, овца, глаза, усы, уши, рога, шляпы, галстук, шарф, птицы, солнце, лягушка, чеширский кот, медали, награды, коты, ангел, сердце, мечты, еда, морожное, надписи, head, lion, sheep, glasses, spectacles, eyes, mustache, ears, horns, hats, tie, scarf, birds, sun, frog, Cheshire Cat, medals, cats, angel, heart, dream, food, ice cream, inscriptions, Masks VI: Glitter, telegram",
+    "nsfw": false
+},
+"7d28deab9b11c914895eb295564d0f44": {
+    "key": "457d3749d6dd10ff473213bd788f78942de2fce05372a9b60b1f23e466a235cd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Metal Machine, metalmachine, metal machine, rock, metal, рок, метал, музыканты, Metal Machine, telegram",
+    "nsfw": false
+},
+"37bd942f2341979a9bc88e39cf12bca6": {
+    "key": "2b0adaf905cd99a16dea4e4a55639e9feec357032d36a594edfafe6250b170c0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeria Fortuna, michael, вконтакте, медведь, животные, bear, animals, Michael, telegram",
+    "nsfw": false
+},
+"30f498bc4ba3086cfcd40d99f268e6e7": {
+    "key": "82f8abec9fb0f9f21cc0cb3adf33b35159d3812ae2a0f3e14dd4d3dceb1d43df",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeria Fills, milkstrawberry, клубничка, девушка, тян, аниме, anime, cute, girl, Клубничка (@Valeria_fills_art), telegram",
+    "nsfw": false
+},
+"9713fdd18fb396f92bb7aaeab6227982": {
+    "key": "1bb2a9902503ea76d7ac761b42a10b6c8269354770c160de38f8e0e98342eecb",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, mirby, ютуб, youtube, арт, Аниматор Мирби @lennysticker, telegram",
+    "nsfw": false
+},
+"885ef3d08e7e25335dc43f198eada867": {
+    "key": "d4c782f6a31eef6d83ed462325e386917750a022fdebbd0726d9c85dd2748f34",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "modernlife, мультфильм, cartoon, сериал, series, tv, Rocko's modern life, telegram",
+    "nsfw": false
+},
+"40999afd1ece44885dc4323b4bf75d6c": {
+    "key": "1d78a09d1e021adfb8ee5671f6059a9394d89f212c3246aae1cbd88fda58722b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "modernlife_2, мультик, сериал, tv, shows, cartoon, Rocko's modern life (pack-2), telegram",
+    "nsfw": false
+},
+"9b93019b59ddd2ba75ba08c1c3dcb33d": {
+    "key": "7a84a959429986d095a6f0ec0302df3a5be6f998718a0d25d0d4b1ec24c185ed",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "molares, teeth, зубы, molars, telegram",
+    "nsfw": false
+},
+"ee472bdf7fef96b9e9561dae0a1b852a": {
+    "key": "2eca9d6d7de60da65e935fdd6be10392399146d7ef76813e1646bd0f68a8ceb1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Pixar, monsters_inc, мультик, для детей, монстры, дисней, cartoon, for children, disney, monsters, Monsters, Inc., telegram",
+    "nsfw": false
+},
+"261c4cc42ac24e79b9a23b0b6e4d05c3": {
+    "key": "4b45c0475512db36e93163e0d187d2cfc4c44d299302b1e414bf77cc54aceafc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Марина Климова, moodalien, monster, монстр, чудики, Эмоции, telegram",
+    "nsfw": false
+},
+"b6d2bbb385bf024555f7c7f5ddd423a1": {
+    "key": "19c6271cf37a26cf351459dfc977fdf14c0fdade2d7f949cfa808f9469fb7ba3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Clementine, moonygoonies, friends, girls, art, подруги, дружба, художник, MoonyCreepyGoonies, telegram",
+    "nsfw": false
+},
+"27fa27209356b27c86a0320ea8b20582": {
+    "key": "20aa5dcd77c9c008289af0447b7f3368a81f3c1767fcda3efb14eee54133eccf",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Artur Wulf, morskiesvinki, животные, свинки, animals, Морские свинки, telegram",
+    "nsfw": false
+},
+"d3d13f88dd8c1ef43b63360fdad5649d": {
+    "key": "35779546083832ccab5fb7f31116bdfa4fa45e11e7899f01c6eae602a9d1b763",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Motul, motulbiker, мото, moto, транспорт, мотоцикл, motul, telegram",
+    "nsfw": false
+},
+"58d393087767584ba0d985684bd7b884": {
+    "key": "ff224ef66a6a143c7c59bfe43f9f01e82133925536d05128872aded0de569344",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Helen Helena, mr_monster, monster, монстр, ужасы, horror, mr.monster, telegram",
+    "nsfw": false
+},
+"62aa1c6b174c715b263c31f4175eb515": {
+    "key": "98d60d7da67589fbbe472cff5be4f043337e24436308b380f2abb20218e2e16d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Карина Ли, mr_octopus, осьминог, животные, animsls, octopus, mr. Octopus, telegram",
+    "nsfw": false
+},
+"b2b4154b6d810ade54f286463e7a28ce": {
+    "key": "096a69243a4e31d495a31aeceb9b5f1e5756b78b1847d0350cf2e9e37d3bb314",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "mrbeansticker, Movies, People, tv, люди, актеры, сериал, смешно, известные личности, Mr. Bean, telegram",
+    "nsfw": false
+},
+"68fcfb9d442a15c7c02b5b7f5e118dc6": {
+    "key": "7e7fcef6321ae4078ce58c87d2c024cd8d70c29bd790045566f16c3eac30589d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "mrcoffee, кофе, кружка, утро, чашка, coffee, mug, morning, cup, Mr.coffee, telegram",
+    "nsfw": false
+},
+"b51bb8c4ce957dcbcda84b4e221a83cb": {
+    "key": "729f5ad3c9def13aaac02a2c112db1ec2f2a36038ae7dede257e8a58facf8165",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ilya Tsvetkov, mrginger, лиса, животные, fox, animals, Mr. Ginger by @nClear, telegram",
+    "nsfw": false
+},
+"2a3be327332285afce9160a6ba1cdb03": {
+    "key": "018a648c2be617988951cb1cbfb76e9229f0f03609063e6ff0327ec7f009ab6b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Алиса Щекотова, musically_alien, космос, инопланетянин, чужой, надписи, фразы, планета, musically_alien, telegram",
+    "nsfw": false
+},
+"e3802348800bd1602fb7a6d34ce08fb2": {
+    "key": "c505f6a534102fc330649a5bede956a5b6dd15ed35dea77ef3e47f70a55d34b9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "nagilotusflower, девочка, цветок, лотус, flower, plants, girl, растения, Nagi Lotus flower, telegram",
+    "nsfw": false
+},
+"bdeb5aceccb3b2687d520648774f713c": {
+    "key": "3e78133ee4da58fdc395de4bf773b17674679edc44ee82e65e4f209acf543647",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "nalaandwhitecoffeecat, коты, животные фразы, Cats, animal phrases, Line, iMessage, Nala & White Coffee Cat, telegram",
+    "nsfw": false
+},
+"71308f3a06a9e088e1b7d751fb5b3bdb": {
+    "key": "c8d74f286ab83d8f88de61ddf7ce025ba062ea3ff80eb4f0214a6b856b6d6203",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "nazodog, собака, животные, animals, dogs, nazodog, telegram",
+    "nsfw": false
+},
+"dffca522cd56ed49c631a138c082cda0": {
+    "key": "797601b4d7b7978b0d47dd781ffacc28328d312667bb2459cf4b7fec0d4c7db0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "EeZee Stickers, new_Kaomoji_stickers, смайлики, эмоции, символы, smiles, Каомодзи, telegram",
+    "nsfw": false
+},
+"11742378dfc5591d2d2e74a01ccf8fc9": {
+    "key": "dcea9e103b83ebb5636830c1d7bcc6550fde146289a394facf6ff63dcb5d1111",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "EeZee Stickers, new_Tom_and_Jerry_stickers, кот, мышь, животные, мультик, длядетей, cat, mouse, animals, cartoon, Том и Джерри, telegram",
+    "nsfw": false
+},
+"1c1e8463d6abe282e31c212b0f23e6d2": {
+    "key": "73ccf3a972d690c7fcdf1c56f4f48c0bbc96b282b33c59f7e304cc1c090a33a9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Антон Андреев, new_lis, вконтакте, лис, животные, новыйгод, праздник, С Новым Лисом! :: @stickroom, telegram",
+    "nsfw": false
+},
+"e961c8b979b0317d9289eea9d5cb5acc": {
+    "key": "e57d4ddf7bd850095ffcadabefa5eb547812588cf1265afa0efc4f5d69e502c3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "obamasticks, президент сша, негр, политика, president, politics, usa, obama, telegram",
+    "nsfw": false
+},
+"e79a95fec2adf2be1ca619d3f1e72f40": {
+    "key": "cd4a01aece79e06ac2b9f509a14ce4f266f72690553d9eb175713d16a30cded5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ocosmonaut, космонавт, люди, космос, вселенная, скафандр, astronaut, people, space, universe, space suit, ocosmonaut, telegram",
+    "nsfw": false
+},
+"52ebe67c9c593f515f92bea8c2911239": {
+    "key": "6d5a5fbacd18d58a67c58ebb595605f75b03737ddb3062d7c978a4da7c64daa3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Юлия Харцызова, octopus, вконтакте, животные, осьминог, animals, octopus, Отто, telegram",
+    "nsfw": false
+},
+"61524da1ed3858ac8c17e68d6d5fd3e6": {
+    "key": "8541c6075bc868235c7bd81058e936b93cf8a901079afd75cb263b57ae4a678f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "VK Testers, oleg_vk, кролик, технологии, вконтакте, программирование, компьютер, интернет, сисадмин, животные, animals, it, Кролик Олег :: @stickroom, telegram",
+    "nsfw": false
+},
+"cc21fbe62be89a2e971c9f75ac87a571": {
+    "key": "847b61e230fbcef4338ecafb50dfec1a5c63c7c72559a8a722b83a628c1ac0ea",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "otherminds, люди, одри хепберн, известные личности, people, Other Great Minds, telegram",
+    "nsfw": false
+},
+"fc193355920cee48e537312d80b361b5": {
+    "key": "898c629fb8f9c1c9a7415dd279dc8753078b8f135f88ca75d1fce45c9dd205e1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Валерия Марковна, otterjohan, выдра, животные, animals, otter, зверюшка, funny, норка, badger, смешной, cartoon, mink, unanutria, Johan The Otter, telegram",
+    "nsfw": false
+},
+"21e487918fc62586811073d1efbd8e02": {
+    "key": "bd690e6e32e29fac6ef28fc58a9a9ce26d1c59451b66162b9b050e7cabb8ff1a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "our_wonderful_ocean, океан, кит, рыба, fish, whale, Our Wonderfull Ocean, telegram",
+    "nsfw": false
+},
+"8ba1b224d88214e7303175c6b96066c4": {
+    "key": "85d9cb27a88822d73a58f7a84d360666d9978a46dc564b647d8e5ee81ed38e46",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "owlbubo, owl, birds, птицы, сова, Филин Бубо, telegram",
+    "nsfw": false
+},
+"5d356e69b458850b4358ddf2510c6364": {
+    "key": "a75d7c24d271b7816d806ea7ce6e257a07712bbe28c7d1391a084da871b655ac",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "owlkyrktik, сова, птицы, животные, animals, birds, owl, Совушка, telegram",
+    "nsfw": false
+},
+"fd6319e89dd0fe1363b6c8561f4eb85a": {
+    "key": "26086162f817393577a82b32bc3014133a82a33b63cedf88b14099f425dca19f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "owlystickers, животные, птицы, owl, animals, birds, Owly, telegram",
+    "nsfw": false
+},
+"9beab6b1b9da89401d5515dcf93e549d": {
+    "key": "b9f2dc2ee352858c774fd4f8d12ce4ea8018fcfe36d289efb93342003f3fc549",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "paintsila, smile, emotions, эмоции, смайлики, smailiki, telegram",
+    "nsfw": false
+},
+"4cf4818e100c07bc2b4e303c072ee9ad": {
+    "key": "47d4013ba131df03cafd74c9c0682075296b72b14bd86e7c55fd9abd30c21556",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Тамерлан Аскеров, pampulove, медведь, животные, любовь, отношения, сердце, 14 февраля, день всех влюбленных, Bear, animals, bear, love, relationship, heart, February 14, the day of all lovers, Pampu Love, telegram",
+    "nsfw": false
+},
+"6902cbebf293a180492fe3004e8437ec": {
+    "key": "561864a54f15f8a9542328f591603c85e81b77da93e89ddc85dbe0c5da16b51b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Knavishkola, Mushroomova, papkapic, картинки, эмоции, папка, Папка с картинками, folder, image, emotion, Папка с картинками, telegram",
+    "nsfw": false
+},
+"3d7190fdc976ee62b8b950586e52b12e": {
+    "key": "87515e0ab69aae9d4f678100198e98f676189d0bd68709ce2426442ef61f0bd4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Стикеры @artrarium, pencil_artrarium, арт, карандаш, pencil, Pencil @artrarium, telegram",
+    "nsfw": false
+},
+"ed4b215fa1e05a5b1353f43854eb59d1": {
+    "key": "01b8c6cae0ed07d99c01e486ce86e0c2690b7102d9e03d24e918f10b3a2049e4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "penguin, животные, пингвин, penguin, animals, Penguins, telegram",
+    "nsfw": false
+},
+"1a60b59fd1229154a39639f6f9f926df": {
+    "key": "55f27e560a56cddf0b7274bf074bf7c410cf877d0e72ef379781e4862fa11429",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Михаил Голубь, pet_pigs_vinki, вконтакте, винки, свинья, pig, animals, животные, Пак полный свинок, telegram",
+    "nsfw": false
+},
+"ef78522fd4f8b0d2985413bf501a91ce": {
+    "key": "beca17f10b8f15f9509a74a9ad6378f797108fc1bab4ba3834bdc5b28c4a27a0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "philosophyspace, философия, философы, люди, philosophy, Wittgenstein & Co. | @philosophyspace, telegram",
+    "nsfw": false
+},
+"b55e8b6a44f09e0eb66bef7bb7f6b101": {
+    "key": "949ca61907c9f0c8265e9140df16e2e263a2e076daeb75a2fa3e4b25a61e3265",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Четвертной, pig_2019, новыйгод, свинья, животные, символгода, new year, pig, animals, winter, snow, снег, зима, ёлка, Pig_2019, telegram",
+    "nsfw": false
+},
+"740420da2d2975239d2132dceeaf38f1": {
+    "key": "00605d033bbb4359cec042613b2fad1228f8707729c15796374087c74939f885",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "pigeonwithhands, юмор, птица, голубь, руки, мем, birds, pigeon, Pigeons with hands, telegram",
+    "nsfw": false
+},
+"536acf86d80a7e4d3cdfe211bde72304": {
+    "key": "49783a4961db2c86426611268f92ecfe347e303a37b15fca0d53674165fab02c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Жан Аллен, pingvinchik_mur, пингвин, животные, птицы, penguin, animals, bird, Пингвинчик, telegram",
+    "nsfw": false
+},
+"d942392c2a62f7d46a93b18e2f49be4f": {
+    "key": "fba04f312dd68faaad460bc31b655f0b85dcbe155825decaeec812eaab4c3756",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Pitgrill, pitgrill, животные, курица, свинья, корова, cow, pig, hen, animals, PITGRILL.RU, telegram",
+    "nsfw": false
+},
+"0e36858b5b4d693aa3448cb32b4a2270": {
+    "key": "bb653636eed2fdaf198566959d7abb9553dfe7955af3f2d484314365b89203f2",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Настя Дрига, podslushano, вконтакте, олень, подслушано, deer, animals, Olen, telegram",
+    "nsfw": false
+},
+"e5bfb322da30c1c30bf135a209ae0611": {
+    "key": "ff1ed8bcdc221a9b728da07b382ec95f01ac1a50f2d14eccff396218e2bdf718",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "pokemon, покемоны, персонажи, пикачу, слоупок, псайдак, pokemon, pikachu, slowpoke, psyduck, Pokémon, telegram",
+    "nsfw": false
+},
+"a0d7614e180175ad569230e4d9c708a5": {
+    "key": "21d3f88efd9db73ae66189f42a24d22942a5860cadd7c3e463787e764aad8888",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "pontifex, религия, люди, people, Religion, папа римский, pope, Pontifex, telegram",
+    "nsfw": false
+},
+"e7d7258ea7673c9937beeabe55c7149e": {
+    "key": "c66292e1d3042596e8859a736ee17eb38837dd9fd53b446993e8173bd5cda368",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "pony_stickers, животные, пони, мультик, pony, animals, cartoon, Pony, telegram",
+    "nsfw": false
+},
+"1ed7d87b18ad7fdff9917faccff77f9f": {
+    "key": "abbcd27d0052c24db26c3fba4a764df342bb48d35d707a8f493fa5a196c76ff9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "postPicasso, арт, art, живопись, картины, искусство, Picasso, telegram",
+    "nsfw": false
+},
+"992476c3bf18b60620967090664f369c": {
+    "key": "849169a856414c01f8a3dd8b27c28cea48e05e4e871ccefa0bf5d08e35be3690",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "potter_telegram, фильм, гарри, гермиона, movie, Harry Potter, Harry Potter, telegram",
+    "nsfw": false
+},
+"b3f370c8ea4359eda7444b3b0572a202": {
+    "key": "8a410660695e44e6656d6edffb93931e281e48e3ccd7f1f96d602a6872b2f710",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ppap_pem, музыка, клип, pen pineapple apple pen, music, PPAP, telegram",
+    "nsfw": false
+},
+"9957bba417172508549f2d78a5961848": {
+    "key": "34d00af07267d0ffc3a69733917f5063132a6f6d2a9ead2c7d429713185c3e11",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Пряничко, pranichko_krd, енот, животные, пряник, еда, имбирные пряники, raccoon, animals, gingerbread, food, Енот Пряничко :: @pranichko_krd, telegram",
+    "nsfw": false
+},
+"4b2bf67dd8fc635b2aec857bb27bcccb": {
+    "key": "3a4e87f2ac5439321b682596cb7acf5827d9184498ff866c04028c6a0d6f2e60",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Patryk Rzucidło, ptkdev, парень, мужчина, борода, man, people, beard, software developer, @PTKDev by maXfer75 & Tanik72, telegram",
+    "nsfw": false
+},
+"c99c525cfbe2481d9457c4199e3eb349": {
+    "key": "095b5dc348f1bcfa4c86be1b524444cf1287e813fec40e3905f87f394aaeb305",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "pugslifepack, животные, собаки, animals, dog, Pug, telegram",
+    "nsfw": false
+},
+"b49aa220d21668d32690fd4a6db4768f": {
+    "key": "8cd5324688b3b7e9d93d20c9c77a9a9b4157e934c96b8c7825de513be49a05b1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Екатерина Григорьева, pusheen02, животные, кот, cat, animals, пушин, pusheen, Pusheen 2.0, telegram",
+    "nsfw": false
+},
+"ed7fbcec747903cec0a163e78cef4a46": {
+    "key": "cc0ad372eae3b8a9cb7dd2eb36393813726b4936ef6839b7f162e56ae3e215c0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Eckru, pusheen_overwatch_by_eckru, пушин, Pusheen, кот, игры, овервотч, Pusheen Overwatch by Eckru, telegram",
+    "nsfw": false
+},
+"595e21848192d1d1a5033a64b5a951bf": {
+    "key": "01c3214718b95f0edb37713a3680d859fe5b2c25400a8b2925ba911fe2f050d9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "qotoqot, эмоции, грусть, тоска, тлен, стресс, депрессия, общество, слезы, тревога, страх, плач, сон, жизнь, чувства, психология, одиночество, надежда, emotions, sadness, melancholy, disintegration, stress, depression, society, tears, anxiety, fear, crying, dream, life, feelings, psychology, loneliness, hope, Sad Animations (Qotoqot), telegram",
+    "nsfw": false
+},
+"fe9bbc6471857729b2326a4230d914bd": {
+    "key": "967f5d81c65f1a0a443e5d68b6c524d34c864206b6ba21bae56e2ce2300dbd24",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Мари Zeligen, quack_quack_quack, утка, птицы, животные, duck, birds, animals, Quack-Quack by @zeligen7, telegram",
+    "nsfw": false
+},
+"9d716ae271b33697219ae7fa024e0168": {
+    "key": "70908b94b6844630d2b4ebd3fee2bdf87674bb6204da6bb0246968b7a51be6e6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Радужный Рыжик, rainbow_redhead, девочка, люди, рыжая, girls, Rainbow redhead, telegram",
+    "nsfw": false
+},
+"96915addd494621515390dd0f42bc1a1": {
+    "key": "cfc83432e7f08fdcaddb07562f1e285829f0c7451b36b546f0f8b6b58a952329",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "curlywind, rainwormivan, червь, животные, worm, animals, rainwormivan, telegram",
+    "nsfw": false
+},
+"bbadb3ec8dda29cba52e8cc91005990e": {
+    "key": "45142b910494bdc7ac560b6a1d0cac645c84165b101b7193406b32bc701ed6db",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "RANDOWIS.COM, randowis_stickers, Randowis, комиксы, арт, Rando, comics, RANDOWIS.COM, telegram",
+    "nsfw": false
+},
+"66d5f15f6cc4c96ab97c34fc47ae6aed": {
+    "key": "9ac4b6815f66192ba4a2425bc1b052714e989bf81773eadeb09ccb7c9f31c4db",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Veronika Vieyra, rawbeardedpirate, пират, мужик, люди, борода, pirate, man, people, beard, rawbeardedpirate, telegram",
+    "nsfw": false
+},
+"de9ad6b55d0d5bc6500427b08590da82": {
+    "key": "2b68cc13a23d018c643da7d2a6215ba7b7f3b71c294adadd5a5d238168c91684",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Виктор Костенко, red_cat, cat, animals, кот, животные, Рыжий Кот от @StickerManya, telegram",
+    "nsfw": false
+},
+"c396f5450f43791fcad0607e6d6297f5": {
+    "key": "c2a792f4e480c7f706108e8f70ca46be54b4475dd8ca60bea5401be416b61bd1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "reddit_pack, реддит, лого, Reddit stickers., telegram",
+    "nsfw": false
+},
+"230b3beeaaa6ad23f862a946e62496f9": {
+    "key": "24fb22a979fd1ebc6d2ce363abd714a2b909afdd76b0ea6385e99e817946fced",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Tatyana Razgonyaeva, renshu, вконтакте, животные, енот, Renshu, telegram",
+    "nsfw": false
+},
+"1267f0b4aeac05061adbf55084371561": {
+    "key": "a3f227816322c2bdda57206d2d9f9942e85087d17f8ed2aa7db2948acc5a38b6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "retarded_wojak, мемы, юмор, умственно отсталый, memes, Retarded Wojak, telegram",
+    "nsfw": false
+},
+"7d25e0fbaae47100be7bf3bf50881377": {
+    "key": "695710fab0897e7df39eae9e00d833e169a6f80a636788f1234ee01c9638d96b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Riley, riley, собаки, любовь, дружба, отношения, 14 февраля, день всех влюбленных, сердце, животные, Dogs, love, friendship, relationship, February 14, Valentine's day, heart, animals, Riley and Kiro, telegram",
+    "nsfw": false
+},
+"60d58a84aed367d8b751b7865e799446": {
+    "key": "18e404964acbeaab4e4ff10f9f396dec7333f33bbf5b203f966b6c12e6aa9db9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Рина Зенюк, rina_zeniuk, кот, животные, искусство, cat, animals, art, Rinas Blue Cats, telegram",
+    "nsfw": false
+},
+"d646c646cba017bb6eb3178eed693187": {
+    "key": "6ea8b989879f717689852355fe583e28caff9bbc61e1556a01f069989af364c3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "rmrick, Rick and Morty, рик и морти, мультик, cartoon, tv, series, R&M (Rick), telegram",
+    "nsfw": false
+},
+"1bf44f529f630a071ed5606d66d47020": {
+    "key": "57b5451a47ceb30107b448040b31cfe2f56a72ae07e66c903d8fb7cf97b9e8ab",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "rock_artists, рок, музыка, rock-n-roll, rock, music, Rock    :: @gargatimeshow, telegram",
+    "nsfw": false
+},
+"a758cd5b10fb3c6c07847ad45c026179": {
+    "key": "bde83defb8a0096d7bb8e89d9f2a650ccdd25c973829663b6481fa5ee9ce4389",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Валерия V, sadpepe, мемы, животные, лягушка, memes, frog, animals, pepe, toad, pepe, telegram",
+    "nsfw": false
+},
+"29c0c07a179dc7594e8eceb8f8b70c4e": {
+    "key": "a80247c240649dcf7b5c5fa7638d3ef266070118d84aa114891d84aa2fd6df40",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "safaei_stickers_juliet, люди, эмоции, people, girl, девочка, Juliet, telegram",
+    "nsfw": false
+},
+"77f1edfa4be3b0ee9b88e18cd83a9b71": {
+    "key": "bacbd84b2b2acbccfe8d8504cb8b03e78f8f1edfcd14cd84deb04fe1b7ef15bd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "safaei_stickers_teddy, животные, медведь, animals, bear, Teddy, telegram",
+    "nsfw": false
+},
+"59a6c9825acaedb8729b954b795e39cf": {
+    "key": "6c656a6eb53519aeb73d3a86743979f3584987376ed75aa752f47d2f91989998",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "sdelaivibor, пепе, мемы, pepe, memes, СДЕЛАЙ ВЫБОР, telegram",
+    "nsfw": false
+},
+"6cdd77ac7bd8c6daa96f9f4dd44533a2": {
+    "key": "c2370da2271e493d63e035668ac2dc915e9d231b542495151b849c8fc247165d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Евгения Седова, seal_vk, животные, animals, вконтакте, Соня / Sonya the seal, telegram",
+    "nsfw": false
+},
+"8674965446105be6c883095964169b03": {
+    "key": "d9ef351c78cf4670f7070ed61cf67c594768e0ea448e48a41c8e37188c5f7f2a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "see_you_next_summer, cartoon, мультик, Gravity Falls, telegram",
+    "nsfw": false
+},
+"09dfefd35e6930df63649441f08c1f1e": {
+    "key": "d2692661b85b6b6cefa94ea84ef4a27f17b757482fdbc088aef88a33c61c6fe3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "sharkweekonline, животные, рыбы, animals, sharks, fish, sharks, telegram",
+    "nsfw": false
+},
+"09278c21a1070e28a49cd0e2285e95fc": {
+    "key": "62a68592c3bec2b9fe74cc30da3a3d70ed548bd5d59ad6884827cb5abf7d77da",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ShepArt, shepart_cac, растения, plants, Cactus, telegram",
+    "nsfw": false
+},
+"a6628c30acfc3497b76f8a0a3d9548af": {
+    "key": "875015c937fb1dc023f8a74855f071d11c969c21191c7c279ed41a43ca5ec400",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Юлия Бобкова, shtogren, жираф, животные, animals, giraffe, Giraffe_Shtogren, telegram",
+    "nsfw": false
+},
+"9d858d4d03803480a7cd9c805dd8b2db": {
+    "key": "98443eff53ad1c4014505aab8a92ca6aee7394722a4c57b2bc1768725a62f9d3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Настя Дрига, shunya, вконтакте, еж, животные, animals, hedgehog, Shunya, telegram",
+    "nsfw": false
+},
+"e61d74eaa4c84d2882034f224246cc51": {
+    "key": "121d017cd42ab312a3f1e4dbad182a77051a815ea0efc5284485846446828637",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "simonscatt, кот, животые, саймон, cat, animals, simon's cat, telegram",
+    "nsfw": false
+},
+"a1af9dc354b9731c911d25cc29f4f28c": {
+    "key": "ea05ba33139165fe9480d75914bd7888403a5ee9372c82a92db8935391c8fdfd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "simple_message_for_you, английский, фразы, english, frases, simple message, telegram",
+    "nsfw": false
+},
+"d6482d0bef944e8ae264388492b0a1a6": {
+    "key": "ce50627e4921d89fe8ab219c06279d4c37bc8dee761060233c2278c7859c88c5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "sintik, люди, парень, эмоции, people, boy, emoji, Sintik, telegram",
+    "nsfw": false
+},
+"5b9c829546494e9b22568f5956ac52e5": {
+    "key": "d3dc36327b5114e0b4147fa9298bc3eab46d135859e7f94dd3707a9571769810",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "smeshariki, мультик, для детей, нюша, бараш, ежик, крош, лосяш, копатыч, совунья, cartoon, Kikoriki, smeshariki, telegram",
+    "nsfw": false
+},
+"011e277186b9ee24dcfbad968e46ebf3": {
+    "key": "d094ae7f1d908b1b0d6088321a1acb87c0146b3fd10e3f1cd2d863b5a04b23aa",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "snappy_vk, вконтакте, рыба, fish, животные, animals, Snappy (@tstickers), telegram",
+    "nsfw": false
+},
+"74544661d3eb5965fdcd50d8a143f98a": {
+    "key": "7c491e8146b20496756510dedcf0c04031550df20d197cd1ead1775dba048085",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "snowleopardNL, животные, леопард, leopard, animals, Snow Leopard, telegram",
+    "nsfw": false
+},
+"bb43c95206aab405b432c3c79303e183": {
+    "key": "ae024fb1b08a59c8f765ad401a83e7298557c5bd6e6f254cf5bb66c4a0e536fc",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Анна Головкова, sobacathor, собака, животные, animals, dogs, Собакатор, telegram",
+    "nsfw": false
+},
+"082a2b7bf996904391c1db80cb601332": {
+    "key": "f0b3df096fc566ca05eb1d614640673f98c1aac5583cc7e52db6ec339b7ac385",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "souffr, чума, средневековье, крестовый поход, арт, история, history, Middle Ages, history Middle Ages art, plague, Souffrant mittelalter, telegram",
+    "nsfw": false
+},
+"040f49d8c0f6f3c3fef1661dd24dde93": {
+    "key": "227925253347d6a14338abf1e13f7b2a3109b84b772bba17840b60e363f62c60",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, spacerabbits, космос, вселенная, звезды, кролики, животные, милота, space, animals, rabbits, the universe, 🐇 Космичеческие кролики @lennysticker, telegram",
+    "nsfw": false
+},
+"06ee63357dd568340ce7d9c565208260": {
+    "key": "5756e2d8a1e8f586790f3466324a47e70ad45f8c259f3efa76c53fcef2980805",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "sponge, мультик, для детей, cartoon for kids, children, sponge, telegram",
+    "nsfw": false
+},
+"147ebaa73b23d2dfbe13b8a6640541bb": {
+    "key": "ffc73031943d1e10e98c0de342725dcac1c44630b69dbef047efddaa1eca628c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "springdeer, deer, олень, животные, весна, Весенний олень, telegram",
+    "nsfw": false
+},
+"aa7a44475b75431e8222da481ea6e508": {
+    "key": "e41748b6a42ca69a44c67c86a3db34a8d39666b32ad5488217434f3cd821245c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Yulia Khartsyzova, starlui, вконтакте, персонажи, звезда, characters, seastar, star, lui, telegram",
+    "nsfw": false
+},
+"d916723eb2f86f1864cf8f8ac604793b": {
+    "key": "05e3d882a03b92ca152653bf5afb96c83306f3de3a33cc3b7e46da89c84d5bf0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Maria Stel, stelleprog, программирование, технологии, programming, technology, it, ит, Coder's Stickers by @stelleries, telegram",
+    "nsfw": false
+},
+"06457ac861ba340b1ba2195cb53beb36": {
+    "key": "733d7b3ea26e5c3dd13079d24f3a16a7322ff349499e6bdf83486579f0348b81",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Andrey Yakovenko, stickerdogs, вконтакте, животные, собака, animals, dog, Dog, telegram",
+    "nsfw": false
+},
+"956a45a46e630ab564e525c8d704461e": {
+    "key": "7a193ea3ea8a3e16d6dba1af3a0d9f9d8e5941957778768c7dd116f64ef1fb34",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "stpcts, встратые коты, кошки, cats, Stupid cats, telegram",
+    "nsfw": false
+},
+"f6bd4068d77dd974fcec600319d31f5b": {
+    "key": "ec21033a6658e174d4e74582ac3ce07daed96a9ef85e1be57dc3c30c1a2da06a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "surpcat, кот, удивление, cat, animals, животные, surprised cat, telegram",
+    "nsfw": false
+},
+"e04ffc687df91384d5a9744a04b018c9": {
+    "key": "888ee2e6105a19e9631f918ee6faf68f1569feadea955baaaa9a37f67f41295c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Svinsent, svinni, свинья, pig, животные, animals, арт, art, @svinsent, telegram",
+    "nsfw": false
+},
+"31a9b31ad504472a2f440576b3778e1b": {
+    "key": "fd3620f1cde517ba4f048c20dfbef545abd3199fbd4cfe48d05df20a5ea75d08",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Svinsent, svinni3, свинья, животные, арт, дизайн, art, animals, pig, Свинни, telegram",
+    "nsfw": false
+},
+"1c4d690da035acbea7c4b42acadee2be": {
+    "key": "92bc61f2d5450ee43fbad755e289667f0d014b9b8f204410e9cab55945f3636c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Svinsent, svinsentvankok, свинья, животные, арт, дизайн, art, animals, pig, @svinsent coolturizm.ru, telegram",
+    "nsfw": false
+},
+"41a499a981ee512e8ff223b1d6572e28": {
+    "key": "0cbd78229ccc79b70102688ca13beeffb8031e22e1c4f8f06f998aad27b8acb3",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Valeria Fills, sweet_unicorn, unicorn, единорог, животные, animals, Единорожка (@Valeria_Fills_art), telegram",
+    "nsfw": false
+},
+"0aa498c14c0f912ec7f3c151059fd65f": {
+    "key": "2b26c3fa79b8af6c5c17bc5e7b810e3ab2ddf85adbe366780cc36f099a6b8ee7",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Александр Жданов, sweetbunsaddiction, булки, еда, обжорство, надписи, жир, толстый, юмор, Булочная Зависимость, telegram",
+    "nsfw": false
+},
+"8e3050f27a3ae5a0cc2b00a7927b6267": {
+    "key": "049597be10670fbc5fdd695cbd0c14f98ebdd3594c39b07f3d70d0910ab2bf21",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Wargaming.net, tanks_fan, вконтакте, такнки, раки, игра, game, Tanks, World of Tanks Fan, telegram",
+    "nsfw": false
+},
+"14529d3f79972c4f0a102baebe1c2d44": {
+    "key": "82c115a749ae8d1fa535cb6afd3ee4f24e9eff59e87c4b384809c18b7472063d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Danil Osipov, tastyteam, вконтакте, еда, пончик, food, Вкусная команда, telegram",
+    "nsfw": false
+},
+"699f3cc2c1f3c6cde84220aa107060e2": {
+    "key": "ddb285bfa8a48b36c053ba467e1f92963942f7144b6a72a309bbc24e90b7b68d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "tel_moomintroll, книги, сказки, туве янсон, books, fairy tales, tove janson, длядетей, forkids, Moomintroll and All, telegram",
+    "nsfw": false
+},
+"70544d5dfd74265462ac645f0fad8e24": {
+    "key": "ffc39a48d0257109315b298f76dc972a29e2edb8ef3fd6114493c90f3ebca099",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "telekot, животные, кот, animals, cats, telekot, telegram",
+    "nsfw": false
+},
+"52b23c1547be0f8613e0b46875c9a990": {
+    "key": "c63ca597070f14cd7a75e55b0930a3f2efc78585ff96a0955d20e4a05d71e9a1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "The Duck's Factory, the_ducks_factory, утки, птицы, животные, ducks, birds, The Duck's Factory, telegram",
+    "nsfw": false
+},
+"ea128ace5dace7b662144d7c9054124c": {
+    "key": "d94bd6b3a69c5ee5b4bc7740a479eaebb65105b332ed4cfbb8d942ccf1eb0f2c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "thecatgamer, животные, игры, games, animals, коты, cat, The GaMERCaT, telegram",
+    "nsfw": false
+},
+"b1edff156d36a9a91c0c60eec5f2146b": {
+    "key": "9d125aa469edccb29fbc22319e4cfa7f70dd0cd2c941674d5da04250e2dd2a59",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "thecutepotato, картошка, еда, potato, food, Potato, telegram",
+    "nsfw": false
+},
+"b0cf2f10205d0ee7df70d97f04c3081e": {
+    "key": "447ca03ca6e09d7d8e94e2282da40b5b5dfdd94bfef0431726870c3a53f7be0e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "thekesha, кеша, мультик, для детей, ссср, россия, parrot, bird, for kids, НАШ Кеша stickers, telegram",
+    "nsfw": false
+},
+"bd4811c71bcbebbb01a9893e8f488fe8": {
+    "key": "98d79e7e61dbcbdb60660714776c3f8a6d7e401905e22d7177cf7b9dd49ba663",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "thepixelphoenix, thepixelcats, кот, животные, пиксель арт, cat, animals, thepixelcats (by @thepixelphoenix), telegram",
+    "nsfw": false
+},
+"85b66f38033dcfd1c15c99eb9c615b3b": {
+    "key": "c898d9a9dee87d920152c1fcd5e4167974737363fa1ea475ac7f683507600a36",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Thirty Seconds to Mars, thirty_seconds, вконтакте, music, rock, рок, музыка, группа, Thirty Seconds to Mars :: @stickroom, telegram",
+    "nsfw": false
+},
+"7a8d137f0b2cc9f094d6c54050d3c9d3": {
+    "key": "163570edc78977b235a494e56577a5bb942b177d8ba09caa927eb34e2e9143cd",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "tigrylik, tiger, animals, животные, тигр, Тиграля, telegram",
+    "nsfw": false
+},
+"34d26bb9381bf07098433f63cca6dc28": {
+    "key": "460e94ffb9350f8838ad98116036bc5c6607ddec2e35515c2c774c303c0ea62d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "kapeleva_a, top_stretching, спорт, здоровье, растяжка, диета, девушки, sport, stretching, гибкость, тело, topstretching, topstretching, telegram",
+    "nsfw": false
+},
+"d170be0eee4247783e16a0541f398d7f": {
+    "key": "d601f9b3f52fc1e478c894ea69a8a0c1dac5c77f5d4e84db265298d25cbfee4b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "township_mobile, животные, игры, games, animals, Township, telegram",
+    "nsfw": false
+},
+"9ec450ec98f4ca2273ef0061c91207e0": {
+    "key": "209965a8fb29a36111e5661de3c3c405c48dcb1e635c17fa9f75081944e17562",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Anna Triffin, triffin_froggos, animals, животные, лягушка, Froggos by Triffin, telegram",
+    "nsfw": false
+},
+"c034787510afdff3ea8e510e97bcae20": {
+    "key": "45e83356e23ca3f4433ff1cba8d64644cfa619c9b5881f25d3174381fc9b463e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "tylena, животные, animals, Тюленя | Seal @TgSticker, telegram",
+    "nsfw": false
+},
+"a45e52949071db8a25140938417f1dc8": {
+    "key": "fe4efde60e1cd270f20bedf0fadb6055c0aeec47997d7e506a935a775ad3a04e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Julia Cosmo, unicorn_by_cosmo, единорог, animals, животные, Unicorn by Julia Cosmo, telegram",
+    "nsfw": false
+},
+"de878fd28436ce4e888149a0bccffd87": {
+    "key": "03c21db09e95fb36089513e0fa77852be3b5da7b3f37069ec7feb57f8231935e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Upet, upet_com, upet, милота, котики, мимими, cat, kitty, животные, коты, upet.com, telegram",
+    "nsfw": false
+},
+"de4df3ee9597d8170ae462c3379ac82b": {
+    "key": "759bf5c9a157969eb315ac9b9c12391b534df5efa8d5bba302a2b999d56dddb6",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "uxlivepack, дизайн, арт, творчетсво, Glitch by @uxlive, telegram",
+    "nsfw": false
+},
+"1c28283b8a19d436f840c241d952703f": {
+    "key": "8b8c336bf24f73cb01c38bdd890aa9c10050e56c7f5eba9b01b4964855a12a9d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Bethesda Softworks, vault_boy, игры, fallout, апокалипсис, убежище, gaming, game, vault, Vault boy, telegram",
+    "nsfw": false
+},
+"8f94389c52c7d85bfbe64a756ca1c84d": {
+    "key": "821ca7929004bd3c850f4562c2ce1d6b5c262f5cdcdcff75a9ebc96095b0bf8a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, verycutedoggies, собаки, животные, милота, cute, dogs, animals, 🐶 51 very cute doggies @lennysticker, telegram",
+    "nsfw": false
+},
+"66e9be3ebc00a3562c08a560c46ca21b": {
+    "key": "e82591ca13a179df1650a091a54b3c3039bb1164f5278d0eee1fc3d8ba8021f4",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Natalia Silich, vikings_vk, вконтакте, мужчина, средневековье, man, Middle Ages, Vikings, telegram",
+    "nsfw": false
+},
+"996e5b2111759b7e1af16fa9bf03d07f": {
+    "key": "8fb7eeab13d4e05cf63ef05480793ceb33b918c741ab3dd789dfc18f916f8492",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Андрей Яковенко, vk_animals, вконтакте, животные, тигр, saiga, tiger, сайга, desman, выхухоль, leopard, леопард, медведь, bear, bison, бизон, walrus, морж, whale, кит, панда, panda, salmon, лосось, рыбы, fishes, WWF, telegram",
+    "nsfw": false
+},
+"1333d2ee84dcf122312c937a23c4436f": {
+    "key": "d536c8b55dc8ba2143424db142b02feb33a513f5fdf53b93eb92e601df42f2a1",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Илья Шаповалов, vk_borodist, вконтакте, мужчина, борода, мужественность, сила, force, beard, Man, hipster, хипстер, Borodist, telegram",
+    "nsfw": false
+},
+"ae28bf4699f3945eaa9fdc5d650ece8b": {
+    "key": "99e8e435a9537785d6404e92f1eb02ba69d06128a800a377260eb80e8213a4e0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Маргарита Иванова, vk_bulka, собака, новый год, бульдог, еда, оливье, вконтакте, животные, елка, Булька :: @stickroom, telegram",
+    "nsfw": false
+},
+"ee10a0277f63804c3b6828813a25aa9a": {
+    "key": "5d63e7a75fdb781aa156aab73ec763e44780d99fa3d5407ad0336c8d5c3041e0",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Tatyana Geintse, vk_dexter, животные, animals, вконтакте, squirell, Dexter (@tstickers), telegram",
+    "nsfw": false
+},
+"55380f696764bdaaf60b6ae6386cbcc0": {
+    "key": "66283fa2ad94165e8f9ace8fc63e640e46a720456ac4a90cb5b6320d46c7d759",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Ilja Shapovalov, vk_diego, вконтакте, акула, животные, мексика, shark, Mexico, animals, Diego, telegram",
+    "nsfw": false
+},
+"6beb25315a5118f6ef0d83d4b606539a": {
+    "key": "64a8915b519a4d4717f1cb710c92f37c55511932a2bbaea5aa6990579332af5a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mikhail Golub, vk_diggy, вконтакте, животные, собака, пес, dogs, animals, Diggy, telegram",
+    "nsfw": false
+},
+"68919a76415c992681fc7a50375f1930": {
+    "key": "48da44633cc2c260fe1826337519c912a64ee6af8ff7a368f8d914834fa47204",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "ВКонтакте, vk_emoji, emoji, смайл, smiles, эмоджи, вконтакте, Emoji :: @stickroom, telegram",
+    "nsfw": false
+},
+"1421c37aca76344f6ba467861a596829": {
+    "key": "3b092fee5a190f33b1d323e2917c585054901f0b3e646e1636a6b7ce16ef5254",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Nastya Driga, vk_lovebirds, вконтакте, любовь, отношения, сердце, поцелуи, обнимашки, птицы, попугаи, birds, parrot, love, kissing, день святого валентина, 14 февраля, Неразлучники, telegram",
+    "nsfw": false
+},
+"22d6a2ccd3e0f27c4ac723dec3e3167e": {
+    "key": "dd532582f82eced3bf303a884860ab637f4ce7cd59068309a5bca2eda2990eb8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "vk_masks, вконтакте, уши, рога, усы, мордочки, шапки, губы, бантик, корона, очки, глаза, надписи, инопланетянин, знаки, сердце, пицца, галстук, бабочка, подарок, какашка, мелодия, радуга, ears, horns, mustache, faces, hats, lips, bow, crown, spectacles, glasses, eyes, inscriptions, alien, insignia, candies, tears, heart, pizza, tie, gift, piece of shit, melody, rainbow, VK Masks, telegram",
+    "nsfw": false
+},
+"7709aa08de28a89b6a24bbda8e8348f4": {
+    "key": "6608c1d31eb8e3c954c9444156e1d70b2b993667ca9d6bdcf22515a825734007",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mikhail Golub, vk_oslo, вконтакте, животные, снег, зима, медведь, bear, animals, winter, show, Oslo, telegram",
+    "nsfw": false
+},
+"45ec92030f7a36fae9e353a8f96f8b0e": {
+    "key": "16db1f347a39270ebcebd08f40d4f1cf687cc877e28976dbf567bdf75d3d8327",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Наталья Силич, vk_phil, вконтакте, филин, животные, птицы, animals, owl, bird, Phil, telegram",
+    "nsfw": false
+},
+"5e646a49dd6281b819acfee644f82902": {
+    "key": "365d38f2695a0d388d6b6c0b1803a5d1e3a531f79029266613d7993d4340f27b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Mikhail Golub, vk_pillow, вконтакте, подушка, эмоции, мило, emotions, pillow, Pillow, telegram",
+    "nsfw": false
+},
+"830694c34917a0d274ad32f9cac9f109": {
+    "key": "463b9ad86db61b1357befd578a2c617691dde13a1a6bb57fddae351f24bf8a38",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Алеа Фокс, vk_pushistik, смайлик, пушистик, милота, эмоции, emoji, smiles, cute, Пушистик :: @stickroom, telegram",
+    "nsfw": false
+},
+"69f17d364520fea5477fa0cbd1ab70f3": {
+    "key": "8d6eacfc01068a187384e8439c76f5830aaab50f87dad1fe8c6f62aa4b2599c8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "vvkEasy, монстрик, monstruo, monstro, Easy, telegram",
+    "nsfw": false
+},
+"a23f079c374756f3302941d2d817713f": {
+    "key": "42c57c4b66c762ca8e4ca5dca1c14b73f877e4a1f2798a56a23879083b9c9288",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "vvputin, политика, россия, президент, politics, president, russia, putin, telegram",
+    "nsfw": false
+},
+"cda7007a01862482edc9c70fc4770a03": {
+    "key": "ae2b34d21edfbd07c43befc9ab130af747173fa5049ffcda9e104fbc1381f624",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "waddles_pig, гравити фолз, Gravity Falls, Waddles, pig, свинья, животные, animals, Пухля, telegram",
+    "nsfw": false
+},
+"60a4e345e7304e95e2c5a6ddaae111bc": {
+    "key": "eaf5d28d71363a9da1b5606548f2a2c8c4f3d2c4922ae4a3cc968762d4c38ade",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "wanderoveryonder, мультик, для детей, for kids, cartoon, Wander over Yonder, telegram",
+    "nsfw": false
+},
+"a9f419b5e8f91b88d2b586ea6367faa4": {
+    "key": "61907f11cffb64dbf6e0ae6611ea54530a4440ddd9d3a03fcb479694f234d2e9",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Chilavek, weirdrobots, robots, робот, Всратые роботы, telegram",
+    "nsfw": false
+},
+"196365935252fa0957325358ec24aa85": {
+    "key": "f2cb5c9961d899ec9578130b05f85a47b3ab2565b654a409f1423ca9780f155f",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "white_bear_stickers, зима, животные, медведь, winter, snow, bear, christmas, рождество, новыйгод, White Bear, telegram",
+    "nsfw": false
+},
+"7dbe85e31e292e67e75e35bc7214822f": {
+    "key": "2611862649edb1c6abd0b1625cc02fc6c54a08bd889e7ce94ef5cb48ecb6d00e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Olexandra Njavka, whiteghost, ghost, приведение, милота, ужасы, cute, terrible, White ghost, telegram",
+    "nsfw": false
+},
+"fa7ba4c1b79d025701302ac51df9ae1f": {
+    "key": "5be81d994ee0a4177e19ebe769518e708e19c65dcdaaac1c36df8fec39cea832",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "VK, why4ch, зёма великолепный, форч, 4ch, вконтакте, etozema, telegram",
+    "nsfw": false
+},
+"051d9e279bdfcd5fffc72c1a66c70ab0": {
+    "key": "48ab3ed1c23331bf4f12579d2c80084807e0a2c3f0e35fc1087a5e1c71773e96",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Татьяна Колобова, whysosour, лимон, еда, фрукты, fruits, lemon, food, Why so sour?, telegram",
+    "nsfw": false
+},
+"bacc3fbaaff4f824a08a280df05857ff": {
+    "key": "90dd47848ac214b9e888b8ee196f09cce82b7cf1b0ee10e14d63af84eb24dac5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "wonderfulorangecat, кот, животные, аниме, cat, animals, anime, Wonderful orange cat (@n_chronos), telegram",
+    "nsfw": false
+},
+"1a8e32c0d1d303831ddfeb47c604c2c7": {
+    "key": "599337b16d8dbd6e687740ca878616510ef8359c8ef2a1cd83b8ae56b9280042",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, wowakitainu, dogs, animals, собаки, животные, ✨ Акита-ину @lennysticker, telegram",
+    "nsfw": false
+},
+"9a03c06fe81b43a05d694459f6686f18": {
+    "key": "7f0c86ff12c9729cb90ffb1748cda056b1a86d16f03ed15c5a0287a28d56b61e",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, wowcorgi, животные, милота, собаки, dog, animals, Корги @lennysticker, telegram",
+    "nsfw": false
+},
+"5d44d60257e7883e60362e0da1c89530": {
+    "key": "b4d854857098e0e4c05a0df894caca2466e4274550e99642ba62f3ba89c36b9c",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, wowfox, животные, лисы, fox, animals, 🦊 Лисы @lennysticker, telegram",
+    "nsfw": false
+},
+"ef7bb918abd818f3a390e3bcfbc8250d": {
+    "key": "3046e83f913ad84127e3dfd526567c56978bdea2536382e1905f47366381b690",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, wowhusky, собака, животные, animals, dogs, 🐺 Хаски @lennysticker, telegram",
+    "nsfw": false
+},
+"6bb46556ab51779274c829cea9d37c28": {
+    "key": "a64a0d9ff8a0335184517b85fe42ee7fb12e91fdaebda3297f36342f71f7937a",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, wowigorcat, unicorn, animals, единорог, животные, 🦄 Igor @lennysticker, telegram",
+    "nsfw": false
+},
+"60a9dc8b2ffe02a5550815da70a44f50": {
+    "key": "94e033fa172990c41efb1416dcfd49ad3796b402a2c0c5ce83b0a372572683bb",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, wowshaggy, зверек, пушистик, милота, животные, animals, ☁️ Shaggy @lennysticker, telegram",
+    "nsfw": false
+},
+"d2152594b5ad172e2878709467378ce7": {
+    "key": "d51a6cdacd30205b12ccab364dc531ceb82891d500b4551618a36df4cc6f8a56",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Елена Косицина, wowxfiles, фильм, movie, мадлер, скалли, 👽 x-files @lennysticker, telegram",
+    "nsfw": false
+},
+"fdd8d2a419840cb620e4f8d187512702": {
+    "key": "103b3775702049878dc637d7be7851f1b7925aefb134ba96ddf416627b641442",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Avocat, xgfbxfg, кот, животные, cat, animals, Kotiki Lingvistov, telegram",
+    "nsfw": false
+},
+"29c32b5a8cdaadd6d23634f5d2ab2936": {
+    "key": "083fe246590b707571983838005c14863cdd93d1c71fe7536dfd6b601bcab9f8",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "yoda2, movie, tv, star wars, фильм, звездные войны, Yoda, telegram",
+    "nsfw": false
+},
+"607830017211defe7bbb7bc56c27799b": {
+    "key": "74edb5c074cd1135df2d9beb2f7cd9a94b8bb265f2e68c1095f8816d4a1d5510",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "youngloveGS, любовь, влюбленные, день святого валентина, день всех влюбленных, 14 февраля, сердце, пара, отношения, Love, lovers, St. Valentine's Day, Valentine's Day, February 14, heart, couple, relationship, Young.Love_German.Sanchez, telegram",
+    "nsfw": false
+},
+"1afb6c58e49f4d4b8e005f1c95094ef1": {
+    "key": "c4ae4b9eab4b2864e4389010c0143d70f358c825573b43387085ef92f8c78a50",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Мари Zeligen, zeligen7_chii, bird, parrot, animals, животные, птицы, попугай, @zeligen7 chii parrot, telegram",
+    "nsfw": false
+},
+"5932a467e66415c385ff9e32ef4b9e13": {
+    "key": "2715144af024e27e02b383e03ebd4699427b12678b30b8c14fde226c645884a5",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Мари Zeligen, zeligen7_monster, монстр, страшилка, monster, horror story, @zeligen7 purple monster, telegram",
+    "nsfw": false
+},
+"a936b8c1640521303b648cf26d49dd3b": {
+    "key": "fd92180ae10e1963711ad5d9eeffbe5f7c7def72068eaaa6576ce2c36665c018",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "zenart, мозг, органы, человек, внутренности, man, insides, Brain, organs, Зенарт, telegram",
+    "nsfw": false
+},
+"e242136a9060b7dbebe1de23531d1d91": {
+    "key": "b47413c4b6d9a3df3788383c2b90f9662bfc9489e58fe9b207601609affa303d",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "zhisus, религия, religion, jesus, telegram",
+    "nsfw": false
+},
+"1e49949aa1455ae809268dc6ebd1d8a8": {
+    "key": "23bd3506eb629d985066ac67734d53ebe5970a7473059de63637489394705619",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "zootropolisFB, мультик, cartoon, для детей, животные, animals, for kids, Zootropolis FB, telegram",
+    "nsfw": false
+},
+"728e2a1759b49b441a852d993e4979d7": {
+    "key": "7d220e863397e238592d267cdef2576b3cbf78c63d6138ddeaa29b08d40f463b",
+    "source": "https://tlgrm.eu/stickers",
+    "tags": "Михаил Голубь, zuck_vk, вконтакте, утка, птицы, животные, animals, birds, duck, Зак | Zuck, telegram",
     "nsfw": false
 }
 }


### PR DESCRIPTION
Pulled from https://github.com/signal-stickers/signal-stickers.github.io

We might want to wait to merge this until #22 is merged and we have some kind of paged loading. 

Right now people keep porting stickers from telegram, but they're already ported so there are lots of duplicates. Hopefully this will keep people from continuing to copy telegram packs over.

I added "telegram" as a tag to all of them so we could potentially filter them out if we wanted to not show them by default, but I think this site should have all the publicly known stickers listed.