### PR TITLE
Add Elvis the donkey to stickers

### DIFF
--- a/stickers.json
+++ b/stickers.json
@@ -1179,5 +1179,11 @@
     "source": "Saul O'Gorman",
     "tags": "oc, kid art",
     "nsfw": false
+},
+"107acdd3185620e983d00440302be101": {
+    "key": "799d95aadc54bb04370b07e2b65eaa1898f7cf61810a6eb49dc7526f96f77f66",
+    "source": "http://vkclub.su/en/stickers/elvis/",
+    "tags": "donkey",
+    "nsfw": false
 }
 }


### PR DESCRIPTION
Hey,

Some info about sticker pack can be found below.

Author:  Mikhail Golub
Name: Elvis the donkey
Source: http://vkclub.su/en/stickers/elvis/
Signal Art URL: https://signal.art/addstickers/#pack_id=107acdd3185620e983d00440302be101&pack_key=799d95aadc54bb04370b07e2b65eaa1898f7cf61810a6eb49dc7526f96f77f66 

Cheers,
Furai