### PR TITLE
fix: Gracefully handle browser storage unavailability.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2575,6 +2575,12 @@
       "integrity": "sha1-a9p9uGU/piZD9e5p6facEaOS46Y=",
       "dev": true
     },
+    "@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true
+    },
     "@types/serve-static": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
@@ -10668,11 +10674,12 @@
       "dev": true
     },
     "p-retry": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
-      "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
+      "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
       "dev": true,
       "requires": {
+        "@types/retry": "^0.12.0",
         "retry": "^0.12.0"
       }
     },
@@ -14853,6 +14860,15 @@
           "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
           "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
           "dev": true
+        },
+        "p-retry": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
+          "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
+          "dev": true,
+          "requires": {
+            "retry": "^0.12.0"
+          }
         },
         "require-main-filename": {
           "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "js-yaml": "^3.13.1",
     "mini-css-extract-plugin": "^0.9.0",
     "npm-run-all": "^4.1.5",
+    "p-retry": "^4.2.0",
     "progress": "^2.0.3",
     "raw-loader": "^4.0.0",
     "style-loader": "^1.1.2",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,29 +1,26 @@
 import bytes from 'bytes';
 
-/**
- * Capitalizes the first letter of the provided string.
- */
-export function capitalizeFirst(str: string) {
-  return str.substr(0, 1).toUpperCase() + str.substr(1);
-}
-
 
 /**
  * Prints current storage usage and quotas to the console.
  */
 export async function printStorageUsage() {
-  if (process.env.NODE_ENV !== 'development') {
-    return;
-  }
+  if (process.env.NODE_ENV === 'development') {
+    const storageEstimate = navigator.storage && await navigator.storage.estimate();
 
-  const storageEstimate = await navigator.storage.estimate();
+    // The navigator.storage object is undefined when using private mode in
+    // Safari.
+    if (!storageEstimate) {
+      return;
+    }
 
-  // @ts-ignore
-  const idbUsage = storageEstimate?.usageDetails?.indexedDB;
-  const quota = storageEstimate.quota;
+    // @ts-ignore (usageDetails is not typed correctly).
+    const idbUsage = storageEstimate?.usageDetails?.indexedDB;
+    const quota = storageEstimate.quota;
 
-  if (idbUsage && quota) {
-    const percentageUsed = ((idbUsage / quota) * 100).toFixed(2);
-    console.debug(`IndexedDB is currently using ${bytes(idbUsage)} of data, or ${percentageUsed}% of the ${bytes(quota)} quota.`);
+    if (idbUsage && quota) {
+      const percentageUsed = ((idbUsage / quota) * 100).toFixed(2);
+      console.debug(`IndexedDB is currently using ${bytes(idbUsage)} of data, or ${percentageUsed}% of the ${bytes(quota)} quota.`);
+    }
   }
 }


### PR DESCRIPTION
This update addresses https://github.com/romainricard/signalstickers/issues/50 by gracefully handling errors related to browser storage backends being unavailable. Specifically, this handles the Firefox private mode case. I did a quick test in Safari private mode on macOS and iOS, and we don't seem to be experiencing any issues there at the moment.

Additionally:
* Tweaked the storage usage utility function, which _was_ having an issue in Safari private mode due to `navigator.storage` being unavailable in that context.
* Added retry logic to `FetchStickerDataPlugin`, as I've been seeing some intermittent `500`s in the builds that required a manual re-run of the job.