### PR TITLE
Refactor sticker sorting

### DIFF
--- a/src/contexts/StickersContext.tsx
+++ b/src/contexts/StickersContext.tsx
@@ -58,9 +58,9 @@ export const Provider = (props: PropsWithChildren<{}>) => {
     // Set the canonical list of all sticker packs.
     setAllStickerPacks(stickerPacks);
 
-    // Finally, set our search results to the set of all sticker packs, sorted
-    // by title.
-    setSearchResults(R.sortBy(R.path<any>(['manifest', 'title']), stickerPacks));
+    // Finally, set our search results to the set of all sticker packs,
+    // using the default sort order (most recently added first).
+    setSearchResults(stickerPacks);
   }, []);
 
 
@@ -74,13 +74,10 @@ export const Provider = (props: PropsWithChildren<{}>) => {
 
     const rawSearchResults = fuzzySearchStickerPacks(searchQuery, allStickerPacks);
 
-    // Sort search results by title.
-    const sortedSearchResults = R.sortBy(R.path<any>(['manifest', 'title']), rawSearchResults);
-
     // Only call `setSearchResults` if our new results have actually changed.
     // This will save us superfluous re-renders.
-    if (!R.equals(sortedSearchResults, searchResults)) {
-      setSearchResults(sortedSearchResults);
+    if (!R.equals(rawSearchResults, searchResults)) {
+      setSearchResults(rawSearchResults);
     }
   }, [searchQuery]);
 

--- a/src/lib/stickers.ts
+++ b/src/lib/stickers.ts
@@ -179,7 +179,7 @@ export async function getConvertedStickerInPack(id: string, key: string, sticker
  */
 export function fuzzySearchStickerPacks(needle: string, haystack: Array<StickerPack>): Array<StickerPack> {
   const searchKeys = ['manifest.title', 'manifest.author', 'meta.tags'];
-  const searcher = new FuzzySearch(haystack, searchKeys, {caseSensitive: false});
+  const searcher = new FuzzySearch(haystack, searchKeys, {caseSensitive: false, sort: true});
   return searcher.search(needle);
 }
 

--- a/src/plugins/FetchStickerDataPlugin.ts
+++ b/src/plugins/FetchStickerDataPlugin.ts
@@ -72,7 +72,10 @@ async function getAllStickerPacks(inputFile: string): Promise<Array<StickerPackP
         await fs.writeJson(cachePath, stickerPackPartial);
       }
 
-      stickerPackPartials.push(stickerPackPartial);
+      // Order partials in the reverse order of stickers.yml, so the most
+      // recently added pack is first (assuming stickers.yml is only ever
+      // appended to when new packs are added).
+      stickerPackPartials[stickerPackEntries.length - index - 1] = stickerPackPartial;
       bar.tick();
     }, {retries: 2});
   }));


### PR DESCRIPTION
This is an attempt to better sort stickers by default. There are two major changes:
* When not searching packs are rendered in the reverse from `stickers.yml` – this means if we always insert new packs at the end of the yml file, the most recently added packs will show up first. (If we decide to merge this it will resolve #65)
* When searching, packs are ordered based on their percent match to the query, so ideally the most relevant packs will show up first (e.g. now if you search for "cat" the first packs that show up make sense, rather than the first being "60's Captain America")

I think both of these changes will help users best find what they want.

You can try this out here: https://sticker201.github.io/signalstickers/

