### PR TITLE
Add default tags to pony packs

### DIFF
--- a/stickers.yml
+++ b/stickers.yml
@@ -17950,6 +17950,8 @@ b5b4b47a1c8a3de9bc5e70c16f9f90a7:
       - mlp
       - twilight sparkle
       - pony
+      - for children
+      - cute
     nsfw: false
 5ece3f2fca8ce1f27d6cd7982d9e0368:
     key: 9ba005282659fd767e7e6fa1b7a7ab96120d13d7f5baab4580e4c3396e1e085a
@@ -17959,6 +17961,8 @@ b5b4b47a1c8a3de9bc5e70c16f9f90a7:
       - mlp
       - sweetie belle
       - pony
+      - for children
+      - cute
     nsfw: false
 dc43d87e3ae636cf37d177e1804de0c9:
     key: ab7bbb1e11f50666f85bf79d05af00c722ecc497caf5219bce3f8b44064ae8b8
@@ -17968,6 +17972,8 @@ dc43d87e3ae636cf37d177e1804de0c9:
       - mlp
       - scootaloo
       - pony
+      - for children
+      - cute
     nsfw: false
 ef80211de919e8112f1151f23ab605aa:
     key: 7dffb98a4b7b3a0e8869a917a2759c7da0394bec5cc96a871e3c7d5103a73847
@@ -17977,6 +17983,8 @@ ef80211de919e8112f1151f23ab605aa:
       - mlp
       - rarity
       - pony
+      - for children
+      - cute
     nsfw: false
 9b401e86b80d8de20c2690b094002679:
     key: 229cd0d0702c726c94b26005f96633c0ad42b343a5e3e8cd044fd9c3ed88e7d3
@@ -17986,6 +17994,8 @@ ef80211de919e8112f1151f23ab605aa:
       - mlp
       - fluttershy
       - pony
+      - for children
+      - cute
     nsfw: false
 ed60b64063375ca99e70edb5532e2b5a:
     key: 5edafde4dd671fc54445f228963f84c5a2029357ba8e91dc7863e5a03f314e41
@@ -17995,6 +18005,7 @@ ed60b64063375ca99e70edb5532e2b5a:
       - mlp
       - discord
       - pony
+      - for children
     nsfw: false
 8a164d1917cbd5820f2424a32f09078f:
     key: d576c8abbe51f15f20ca4c1c79fbe3b18fbd55197ae769046838de162768d926
@@ -18004,6 +18015,8 @@ ed60b64063375ca99e70edb5532e2b5a:
       - mlp
       - applejack
       - pony
+      - for children
+      - cute
     nsfw: false
 54572d56d3ce973e8572ab18e3292fd1:
     key: a9f5b10581b10e3b91f6498ef9719ca8b2438f64cbc48af5018cda37d993a304
@@ -18013,6 +18026,8 @@ ed60b64063375ca99e70edb5532e2b5a:
       - mlp
       - apple bloom
       - pony
+      - for children
+      - cute
     nsfw: false
 2de676485ffde69097d484a1a4ce11e0:
     key: b05e756d65a3e96e48d31a6f129000279b11efe931f26d6c7f8ceee4365c37d9
@@ -18023,6 +18038,7 @@ ed60b64063375ca99e70edb5532e2b5a:
       - halloween
       - nightmare night
       - pony
+      - for children
     nsfw: false
 a88750099e5d1d5fac5a634e68c88176:
     key: 771f580b83df32326ec03314d7a01c39a8cbb9c4777d4911c3cdc2b15417fe16
@@ -18032,6 +18048,8 @@ a88750099e5d1d5fac5a634e68c88176:
       - mlp
       - pinkie pie
       - pony
+      - for children
+      - cute
     nsfw: false
 1af3eba6c97e3da196988ae49cbea69d:
     key: 478dafb1aeac469303ecf2cb1a0f1efbacf99068f97bb515c91b1c3787cd1988
@@ -18041,6 +18059,8 @@ a88750099e5d1d5fac5a634e68c88176:
       - mlp
       - starlight glimmer
       - pony
+      - for children
+      - cute
     nsfw: false
 9c059dd4f8024b279ddfbb7173b51103:
     key: 3e08180fa62d35fce7e621d7a4a6adbe4b5df5c4104ec0a9a443604385fd0ff0
@@ -18050,6 +18070,7 @@ a88750099e5d1d5fac5a634e68c88176:
       - mlp
       - crystal war
       - pony
+      - for children
     nsfw: false
 c57e162f6119f4f856145e6f54bcf8e1:
     key: 0eb9548afe24d32e9939226be37bb3883d3c5a383f462f6ba589eae6f57bbe94
@@ -18059,6 +18080,9 @@ c57e162f6119f4f856145e6f54bcf8e1:
       - mlp
       - derpy
       - pony
+      - for children
+      - cute
+      - meme
     nsfw: false
 360772220ee89074fa614f46ff58fb83:
     key: 3b5d9baa0bade57f35920b5fd058d1a1e958c1ebe290b1011ca3d1c182d9b56f
@@ -18068,6 +18092,7 @@ c57e162f6119f4f856145e6f54bcf8e1:
       - mlp
       - queen chrysalis
       - pony
+      - for children
     nsfw: false
 05430f3d554947c1f7b6907ad26232b2:
     key: c6beb26faf13b7da40213b9ac039b2a5ada5f86c7bec4db610effc5d4396ccfa
@@ -18077,6 +18102,8 @@ c57e162f6119f4f856145e6f54bcf8e1:
       - mlp
       - trixie
       - pony
+      - for children
+      - cute
     nsfw: false
 ec4a5b7794f3d20dc62f6eff6b198b50:
     key: a1d0b98b8a4016f50dfe28300e233e2d6dda4c99095b6574a66328871e7ce4ab

--- a/stickers.yml
+++ b/stickers.yml
@@ -18215,3 +18215,14 @@ ba771fe4149df880804b68f86eb156d7:
   tags:
     - Gravity Falls
   nsfw: false
+aaac975582921851fb7a10d7a34069ec:
+  key: ea76773056c447c9131b515de4d090191d9c1eb75c8863caac8694b2ee55cb2a
+  source: "@MLP_Stickers"
+  tags: 
+    - my little pony
+    - mlp
+    - fluttershy
+    - pony
+    - for children
+    - cute
+  nsfw: false


### PR DESCRIPTION
i noticed that a new search suggestions was added. i updated my packs tags to support this

i also add a missing pack https://signalstickers.com/pack/aaac975582921851fb7a10d7a34069ec?key=ea76773056c447c9131b515de4d090191d9c1eb75c8863caac8694b2ee55cb2a