### PR TITLE
Mention https://framagit.org/luc/stickerify-for-signal in README

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -46,6 +46,10 @@ um Ihre Stickers auf Signal hochzuladen.
 > können dieses [Skript](https://gist.github.com/ondondil/4b8564b404696b3255253b467b413de9#gistcomment-3118471) 
 > verwenden.
 
+> Hinweis: Sie können [dieses Projekt](https://framagit.org/luc/stickerify-for-signal)
+> verwenden, um automatisch die Größe aller PNG- und WEBP-Bilder eines Verzeichnisses
+> zu ändern und einen weißen Strich hinzuzufügen.
+
 ### Muss ich mein Sticker-Pack zu dieser Site hinfügen, um es mit meinen Freunden zu teilen?
 
 **Nein**. Sie können einfach jeden Sickers an Ihre Freunde senden und sie können

--- a/README.fr.md
+++ b/README.fr.md
@@ -36,15 +36,19 @@ puisse parcourir les packs d'autocollants tranquillement.
 
 ## Questions fréquentes
 
-### Comment puis-je créer un pack d'autocollants ?
+### Comment puis-je créer un pack d'autocollants ?
 
 Suivez le tutoriel sur [le site de support de
 Signal](https://support.signal.org/hc/en-us/articles/360031836512-Stickers#h_c2a0a45b-862f-4d12-9ab1-d9a6844062ca)
 pour télécharger vos stickers sur Signal.
 
-> Note : lors de la création des stickers, n'oubliez pas d'ajouter un contour
+> Note : lors de la création des stickers, n'oubliez pas d'ajouter un contour
 > blanc pour améliorer la lisibilité sur les thèmes sombres ! Vous pouvez
 > utiliser [ce script](https://gist.github.com/ondondil/4b8564b404696b3255253b467b413de9#gistcomment-3118471).
+
+> Note : vous pouvez utiliser [ce projet](https://framagit.org/luc/stickerify-for-signal)
+> pour redimensionner automatiquement et ajouter un contour blanc sur toutes
+> les images PNG et WEBP d'un répertoire.
 
 ### Dois-je ajouter mon pack d'autocollants sur ce site pour le partager avec mes amis ?
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ to upload your stickers to Signal.
 > Note: when creating stickers, don't forget to add a white stroke to improve
 > legibility on dark themes! You can use [this script](https://gist.github.com/ondondil/4b8564b404696b3255253b467b413de9#gistcomment-3118471).
 
+> Note: you can use [this project](https://framagit.org/luc/stickerify-for-signal)
+> to automatically resize and add a white stroke on all the PNG and WEBP images
+> of a directory.
 
 ### Do I have to add my sticker pack to this site to share it with my friends?
 **No**. You can just send any sticker to your friends and they will be able to


### PR DESCRIPTION
This is a script to download (optionally) images, resize them to 512x512
with a 16px padding and add a white stroke on images.